### PR TITLE
Build and test on macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,46 @@
-language: c
+language: generic
+
+env:
+  - BUILD_TYPE=RELEASE
+  - BUILD_TYPE=DEBUG
+
+os:
+  - linux
+  - osx
+
+compiler:
+  - gcc
+  - clang
 
 matrix:
-  include:
-    - os: linux
-      compiler: gcc
+    exclude:
+        - os: osx
+          compiler: gcc
+        - os: linux
+          compiler: clang
 
 addons:
-  apt:
-    packages:
-      - valgrind
-      - python-numpy
+    apt:
+      sources:
+        - george-edison55-precise-backports
+      packages:
+        - cmake
+        - cmake-data
+        - valgrind
+        - python-numpy
 
-script:
-    - mkdir build
-    - cd build
-    - cmake ..
-    - make -j2
-    - export LD_LIBRARY_PATH=$PWD
-    - ctest -j2 --output-on-failure
+before_script:
+  # Valgrind is experimental(ish) on MacOS with false positives on among others printf
+  #- if [[ "$TRAVIS_OS_NAME" == "osx" && "$BUILD_TYPE" == "DEBUG" ]]; then
+  #    brew update;
+  #    brew install --HEAD valgrind;
+  #  fi
+
+  - cmake --version
+  - mkdir build
+  - cd build
+  - cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE ..
+  - make
+  - export LD_LIBRARY_PATH=$PWD
+
+script: make && ctest --output-on-failure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ endif ()
 option(BUILD_MEX    "Build Matlab mex files"    OFF)
 option(BUILD_PYTHON "Build Python wrappers"     ON)
 
-include(cmake/python.cmake)
+include(cmake/segyio_testing.cmake)
 enable_testing()
 
 set(CMAKE_C_FLAGS "-std=c99 ${CMAKE_C_FLAGS}")
@@ -71,6 +71,7 @@ else (BUILD_MEX)
 endif ()
 
 if (BUILD_PYTHON)
+    include(cmake/python.cmake)
     add_subdirectory(python)
 endif ()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,18 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8.8)
 project(segyio)
 
-if(POLICY CMP0042)
+if (POLICY CMP0042)
     cmake_policy(SET CMP0042 NEW)
-endif()
+endif ()
+
+if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+    set(MAC_OS TRUE)
+elseif (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+    set(LINUX TRUE)
+    set(CMAKE_C_FLAGS "-fPIC ${CMAKE_C_FLAGS}")
+elseif (${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+    set(WINDOWS TRUE)
+endif ()
 
 option(BUILD_MEX    "Build Matlab mex files"    OFF)
 option(BUILD_PYTHON "Build Python wrappers"     ON)
@@ -14,10 +23,12 @@ enable_testing()
 set(CMAKE_C_FLAGS "-std=c99 ${CMAKE_C_FLAGS}")
 
 if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
-    set (CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}/install" CACHE PATH "Default install path" FORCE )
-endif()
+    set(CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}/install" CACHE PATH "Default install path" FORCE)
+endif ()
 
-#set(CMAKE_BUILD_TYPE RELEASE)
+if(NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Choose the type of build, options are: Debug Release RelWithDebInfo MinSizeRel." FORCE)
+endif(NOT CMAKE_BUILD_TYPE)
 
 include_directories(src)
 
@@ -25,37 +36,15 @@ set(SOURCE_FILES src/segyio/segy.c src/spec/segyspec.c)
 
 install(FILES src/segyio/segy.h DESTINATION ${CMAKE_INSTALL_PREFIX}/include/segyio)
 
-add_library(segyio-static STATIC ${SOURCE_FILES})
+# The object library type is a reusable component for later builds: shared, static and python
+add_library(segyio-object OBJECT ${SOURCE_FILES})
+
+add_library(segyio-static STATIC $<TARGET_OBJECTS:segyio-object>)
 set_target_properties(segyio-static PROPERTIES OUTPUT_NAME segyio CLEAN_DIRECT_OUTPUT 1)
 set_target_properties(segyio-static PROPERTIES COMPILE_FLAGS "-fPIC")
 
-add_library(segyio-shared SHARED ${SOURCE_FILES})
+add_library(segyio-shared SHARED $<TARGET_OBJECTS:segyio-object>)
 set_target_properties(segyio-shared PROPERTIES OUTPUT_NAME segyio CLEAN_DIRECT_OUTPUT 1)
-
-
-if(BUILD_PYTHON)
-    find_package(PythonInterp)
-    find_package(PythonLibs REQUIRED)
-
-    if (PYTHONLIBS_FOUND)
-        include_directories(${PYTHON_INCLUDE_DIRS})
-        add_library(_segyio SHARED python/segyio/_segyio.c ${SOURCE_FILES})
-
-        if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-            set_target_properties(_segyio PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")
-        else()
-            set_target_properties(_segyio PROPERTIES LINK_FLAGS "-Xlinker -export-dynamic")
-        endif()
-
-        set_target_properties(_segyio PROPERTIES PREFIX "" SUFFIX ".so")
-        install(TARGETS _segyio DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/python2.7/site-packages/segyio)
-
-        add_custom_command(TARGET _segyio POST_BUILD
-                COMMAND ${CMAKE_COMMAND} -E copy
-                ${CMAKE_BINARY_DIR}/_segyio.so ${CMAKE_BINARY_DIR}/python/segyio/_segyio.so)
-    endif()
-    add_subdirectory(python)
-endif()
 
 install(TARGETS segyio-static segyio-shared DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)
 
@@ -79,7 +68,11 @@ else (BUILD_MEX)
     unset(MATLAB_MEXEXT CACHE)
     unset(MATLAB_ROOT CACHE)
     unset(BUILD_MEX_TESTS CACHE)
-endif()
+endif ()
+
+if (BUILD_PYTHON)
+    add_subdirectory(python)
+endif ()
 
 add_subdirectory(tests)
 add_subdirectory(examples)

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ interpreter and type `help(segyio)` to get started.
 
 To build and use Segyio you need:
  * A C99 compatible C compiler (tested mostly on gcc and clang)
- * [CMake](https://cmake.org/) version 2.8 or greater
+ * [CMake](https://cmake.org/) version 2.8.8 or greater
  * [Python](https://www.python.org/) 2.7. We're working on 3.x support, help
    appreciated!
 

--- a/cmake/find_python_module.cmake
+++ b/cmake/find_python_module.cmake
@@ -1,0 +1,27 @@
+# Found from: github user ivansafrin
+#
+# Find if a Python module is installed
+# Found at http://www.cmake.org/pipermail/cmake/2011-January/041666.html
+# To use do: find_python_module(PyQt4 REQUIRED)
+function(find_python_module module)
+    string(TOUPPER ${module} module_upper)
+    if(NOT PY_${module_upper})
+        if(ARGC GREATER 1 AND ARGV1 STREQUAL "REQUIRED")
+            set(${module}_FIND_REQUIRED TRUE)
+        endif()
+        # A module's location is usually a directory, but for binary modules
+        # it's a .so file.
+        execute_process(COMMAND "${PYTHON_EXECUTABLE}" "-c"
+                "import re, ${module}; print(re.compile('/__init__.py.*').sub('',${module}.__file__))"
+                RESULT_VARIABLE _${module}_status
+                OUTPUT_VARIABLE _${module}_location
+                ERROR_QUIET
+                OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+        if(NOT _${module}_status)
+            set(PY_${module_upper} ${_${module}_location} CACHE STRING
+                    "Location of Python module ${module}")
+        endif()
+    endif(NOT PY_${module_upper})
+    find_package_handle_standard_args(PY_${module} DEFAULT_MSG PY_${module_upper})
+endfunction(find_python_module)

--- a/cmake/python.cmake
+++ b/cmake/python.cmake
@@ -1,19 +1,17 @@
+include(cmake/find_python_module.cmake)
+include(cmake/python_module_version.cmake)
+
+find_package(PythonInterp)
+find_package(PythonLibs REQUIRED)
+
 configure_file(cmake/test_runner.py tests/test_runner.py COPYONLY)
 
-if(WINDOWS)
-    set(SEP "\\;")
-else() # e.g. Linux
-    set(SEP ":")
+if (EXISTS "/etc/debian_version")
+    set( PYTHON_PACKAGE_PATH "dist-packages")
+else()
+    set( PYTHON_PACKAGE_PATH "site-packages")
 endif()
-
-function(add_memcheck_test NAME BINARY)
-    # Valgrind on MacOS is experimental
-    if(LINUX AND (${CMAKE_BUILD_TYPE} MATCHES "DEBUG"))
-        set(memcheck_command "valgrind --trace-children=yes --leak-check=full --error-exitcode=31415")
-        separate_arguments(memcheck_command)
-        add_test(memcheck_${NAME} ${memcheck_command} ./${BINARY})
-    endif()
-endfunction(add_memcheck_test)
+set(PYTHON_INSTALL_PREFIX "lib/python${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}/${PYTHON_PACKAGE_PATH}" CACHE STRING "Subdirectory to install Python modules in")
 
 function(add_python_package PACKAGE_NAME PACKAGE_PATH PYTHON_FILES)
     add_custom_target(package_${PACKAGE_NAME} ALL)
@@ -24,7 +22,7 @@ function(add_python_package PACKAGE_NAME PACKAGE_PATH PYTHON_FILES)
                 COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/${file} ${CMAKE_BINARY_DIR}/python/${PACKAGE_PATH}
                 )
     endforeach ()
-    install(FILES ${PYTHON_FILES} DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/python2.7/site-packages/${PACKAGE_PATH})
+    install(FILES ${PYTHON_FILES} DESTINATION ${CMAKE_INSTALL_PREFIX}/${PYTHON_INSTALL_PREFIX}/${PACKAGE_PATH})
 endfunction()
 
 function(add_python_test TESTNAME PYTHON_TEST_FILE)
@@ -34,9 +32,9 @@ function(add_python_test TESTNAME PYTHON_TEST_FILE)
             WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/tests
             COMMAND python test_runner.py ${PYTHON_TEST_FILE}
             )
-    set_tests_properties(${TESTNAME} PROPERTIES ENVIRONMENT
-                        "PYTHONPATH=${CMAKE_BINARY_DIR}/python${SEP}$ENV{PYTHONPATH}"
-                        )
+
+    to_path_list(pythonpath "${CMAKE_BINARY_DIR}/python" "$ENV{PYTHONPATH}")
+    set_tests_properties(${TESTNAME} PROPERTIES ENVIRONMENT "PYTHONPATH=${pythonpath}")
 endfunction()
 
 function(add_python_example TESTNAME PYTHON_TEST_FILE)
@@ -46,15 +44,6 @@ function(add_python_example TESTNAME PYTHON_TEST_FILE)
             WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/examples
             COMMAND python ${PYTHON_TEST_FILE} ${ARGN}
             )
-    set_tests_properties(${TESTNAME} PROPERTIES ENVIRONMENT
-                        "PYTHONPATH=${CMAKE_BINARY_DIR}/python${SEP}$ENV{PYTHONPATH}"
-                        )
-endfunction()
-
-function(add_segyio_test TESTNAME TEST_SOURCES)
-    add_executable(test_${TESTNAME} unittest.h "${TEST_SOURCES}")
-    target_link_libraries(test_${TESTNAME} segyio-static m)
-    add_dependencies(test_${TESTNAME} segyio-static)
-    add_test(NAME ${TESTNAME} COMMAND ${EXECUTABLE_OUTPUT_PATH}/test_${TESTNAME})
-    add_memcheck_test(${TESTNAME} ${EXECUTABLE_OUTPUT_PATH}/test_${TESTNAME})
+    to_path_list(pythonpath "${CMAKE_BINARY_DIR}/python" "$ENV{PYTHONPATH}")
+    set_tests_properties(${TESTNAME} PROPERTIES ENVIRONMENT "PYTHONPATH=${pythonpath}")
 endfunction()

--- a/cmake/python.cmake
+++ b/cmake/python.cmake
@@ -1,15 +1,18 @@
 configure_file(cmake/test_runner.py tests/test_runner.py COPYONLY)
 
-if("${CMAKE_HOST_SYSTEM}" MATCHES ".*Windows.*")
+if(WINDOWS)
     set(SEP "\\;")
 else() # e.g. Linux
     set(SEP ":")
 endif()
 
 function(add_memcheck_test NAME BINARY)
-    set(memcheck_command "valgrind --trace-children=yes --leak-check=full --error-exitcode=31415")
-    separate_arguments(memcheck_command)
-    add_test(memcheck_${NAME} ${memcheck_command} ./${BINARY})
+    # Valgrind on MacOS is experimental
+    if(LINUX AND (${CMAKE_BUILD_TYPE} MATCHES "DEBUG"))
+        set(memcheck_command "valgrind --trace-children=yes --leak-check=full --error-exitcode=31415")
+        separate_arguments(memcheck_command)
+        add_test(memcheck_${NAME} ${memcheck_command} ./${BINARY})
+    endif()
 endfunction(add_memcheck_test)
 
 function(add_python_package PACKAGE_NAME PACKAGE_PATH PYTHON_FILES)

--- a/cmake/python_module_version.cmake
+++ b/cmake/python_module_version.cmake
@@ -1,0 +1,40 @@
+# try import python module, if success, check its version, store as PY_module.
+# the module is imported as-is, hence the case (e.g. PyQt4) must be correct.
+function(python_module_version module)
+    set(PY_VERSION_ACCESSOR "__version__")
+    set(PY_module_name ${module})
+
+    if(${module} MATCHES "PyQt4")
+        set(PY_module_name "PyQt4.Qt")
+        set(PY_VERSION_ACCESSOR "PYQT_VERSION_STR")
+    endif()
+
+    execute_process(COMMAND "${PYTHON_EXECUTABLE}" "-c" "import ${PY_module_name} as py_m; print(py_m.${PY_VERSION_ACCESSOR})"
+            RESULT_VARIABLE _${module}_fail#    error code 0 if success
+            OUTPUT_VARIABLE _${module}_version# major.minor.patch
+            ERROR_VARIABLE stderr_output
+            OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+    if(NOT _${module}_fail)
+        set(PY_${module} ${_${module}_version})# local scope, for message
+        set(PY_${module} ${_${module}_version} PARENT_SCOPE)
+    endif()
+endfunction()
+
+
+# If we find the correct module and new enough version, set PY_package, where
+# "package" is the given argument to the version we found else, display warning
+# and do not set any variables.
+function(python_module package version)
+    python_module_version(${package})
+
+    if(NOT DEFINED PY_${package})
+        message("Could not find Python module " ${package})
+    elseif(${PY_${package}} VERSION_LESS ${version})
+        message(WARNING "Python module ${package} too old.  "
+                "Wanted ${version}, found ${PY_${package}}")
+    else()
+        message(STATUS "Found ${package}.  ${PY_${package}} >= ${version}")
+        set(PY_${package} ${version} PARENT_SCOPE)
+    endif()
+endfunction()

--- a/cmake/segyio_testing.cmake
+++ b/cmake/segyio_testing.cmake
@@ -1,0 +1,29 @@
+function(to_path_list var path1)
+    if("${CMAKE_HOST_SYSTEM}" MATCHES ".*Windows.*")
+        set(sep "\\;")
+    else()
+        set(sep ":")
+    endif()
+    set(result "${path1}") # First element doesn't require separator at all...
+    foreach(path ${ARGN})
+        set(result "${result}${sep}${path}") # .. but other elements do.
+    endforeach()
+    set(${var} "${result}" PARENT_SCOPE)
+endfunction()
+
+function(add_memcheck_test NAME BINARY)
+    # Valgrind on MacOS is experimental
+    if(LINUX AND (${CMAKE_BUILD_TYPE} MATCHES "DEBUG"))
+        set(memcheck_command "valgrind --trace-children=yes --leak-check=full --error-exitcode=31415")
+        separate_arguments(memcheck_command)
+        add_test(memcheck_${NAME} ${memcheck_command} ./${BINARY})
+    endif()
+endfunction(add_memcheck_test)
+
+function(add_segyio_test TESTNAME TEST_SOURCES)
+    add_executable(test_${TESTNAME} unittest.h "${TEST_SOURCES}")
+    target_link_libraries(test_${TESTNAME} segyio-static m)
+    add_dependencies(test_${TESTNAME} segyio-static)
+    add_test(NAME ${TESTNAME} COMMAND ${EXECUTABLE_OUTPUT_PATH}/test_${TESTNAME})
+    add_memcheck_test(${TESTNAME} ${EXECUTABLE_OUTPUT_PATH}/test_${TESTNAME})
+endfunction()

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,5 +1,14 @@
-find_package(PythonInterp)
-find_package(PythonLibs REQUIRED)
+if (NOT DEFINED PYTHON_EXECUTABLE)
+    message("Python interpreter not found - Python wrappers not enabled")
+    return()
+endif()
+
+
+python_module(numpy 1.6)
+if (NOT DEFINED PY_numpy)
+    message("numpy module not found - Python wrappers not enabled")
+    return()
+endif()
 
 if (PYTHONLIBS_FOUND)
     include_directories(${PYTHON_INCLUDE_DIRS})
@@ -12,7 +21,7 @@ if (PYTHONLIBS_FOUND)
     endif ()
 
     set_target_properties(_segyio PROPERTIES PREFIX "" SUFFIX ".so")
-    install(TARGETS _segyio DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/python2.7/site-packages/segyio)
+    install(TARGETS _segyio DESTINATION ${CMAKE_INSTALL_PREFIX}/${PYTHON_INSTALL_PREFIX}/segyio)
 
     add_custom_command(TARGET _segyio POST_BUILD
             COMMAND ${CMAKE_COMMAND} -E copy

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,1 +1,22 @@
+find_package(PythonInterp)
+find_package(PythonLibs REQUIRED)
+
+if (PYTHONLIBS_FOUND)
+    include_directories(${PYTHON_INCLUDE_DIRS})
+    add_library(_segyio SHARED segyio/_segyio.c $<TARGET_OBJECTS:segyio-object>)
+
+    if (MAC_OS)
+        set_target_properties(_segyio PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")
+    else ()
+        set_target_properties(_segyio PROPERTIES LINK_FLAGS "-Xlinker -export-dynamic")
+    endif ()
+
+    set_target_properties(_segyio PROPERTIES PREFIX "" SUFFIX ".so")
+    install(TARGETS _segyio DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/python2.7/site-packages/segyio)
+
+    add_custom_command(TARGET _segyio POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E copy
+            $<TARGET_FILE:_segyio> ${CMAKE_BINARY_DIR}/python/segyio/_segyio.so)
+endif ()
+
 add_subdirectory(segyio)

--- a/tests/test_utils.c
+++ b/tests/test_utils.c
@@ -88,7 +88,7 @@ void testIBMFloat() {
         check(f1, &epsm);
         check(-f1, &epsm);
     }
-    printf("Max eps: %g\n", epsm);
+    assertClose(4.17233e-07, epsm, 1e-06);
 }
 
 int to_int16( const char* );

--- a/tests/unittest.h
+++ b/tests/unittest.h
@@ -29,9 +29,9 @@ void _testAssertTrue(bool value, const char *message, const char *file, int line
 
 #define assertClose(expected, actual, eps) _testAssertClose((expected), (actual), (eps), __FILE__, __LINE__)
 
-void _testAssertClose(float expected, float actual, float eps, const char *file, int line) {
-    float diff = fabsf(expected-actual);
-    if (!(diff <= eps)) {
+void _testAssertClose(double expected, double actual, double eps, const char *file, int line) {
+    double diff = fabs(expected-actual);
+    if (diff > eps) {
         char message[1000];
         sprintf(message, "Expected: %f, Actual: %f, diff: %f, eps: %f\n", expected, actual, diff, eps);
         testAssertionFailed(message, file, line);


### PR DESCRIPTION
Depends on pull request #16 

- Added support for building on MacOS on Travis
- Made it possible to disable Python wrappers
- Building of Debug initializes Valgrind test
- Checks if Numpy module is available
- Dynamically generates the PYTHON_INSTALL_PREFIX
