### PR TITLE
Trace.raw mode for eager reading of traces

### DIFF
--- a/python/segyio/CMakeLists.txt
+++ b/python/segyio/CMakeLists.txt
@@ -4,6 +4,7 @@ set(PYTHON_SOURCES
         _line.py
         _field.py
         _trace.py
+        _raw_trace.py
         segy.py
         tracefield.py
         binfield.py

--- a/python/segyio/_raw_trace.py
+++ b/python/segyio/_raw_trace.py
@@ -1,0 +1,19 @@
+import numpy as np
+import segyio
+
+class RawTrace(object):
+    def __init__(self, trace):
+        self.trace = trace
+
+    def __getitem__(self, index):
+        """ :rtype: numpy.ndarray """
+        buf = None
+        if isinstance(index, slice):
+            f = self.trace._file
+            start, stop, step = index.indices(f.tracecount)
+            mstart, mstop = min(start, stop), max(start, stop)
+            length = max(0, (mstop - mstart + (step - (1 if step > 0 else -1))))
+            buf = np.zeros(shape = (length, f.samples), dtype = np.single)
+
+        return self.trace._readtr(index, buf)
+

--- a/python/segyio/_trace.py
+++ b/python/segyio/_trace.py
@@ -1,5 +1,6 @@
 import numpy as np
 import segyio
+from segyio._raw_trace import RawTrace
 
 
 class Trace:
@@ -70,22 +71,18 @@ class Trace:
             raise TypeError("Buffer must be None or numpy.ndarray")
         elif buf.dtype != np.single:
             buf = np.empty(shape=samples, dtype=np.single)
-        elif buf.shape != samples:
-            buf.reshape(samples)
 
         return buf
 
     def _readtr(self, traceno, buf=None):
-        if traceno < 0:
-            traceno += self._file.tracecount
-
         buf = self._trace_buffer(buf)
 
+        tracecount = self._file.tracecount
         trace0 = self._file._tr0
         bsz = self._file._bsz
         fmt = self._file._fmt
         samples = self._file.samples
-        return segyio._segyio.read_trace(self._file.xfd, traceno, buf, trace0, bsz, fmt, samples)
+        return segyio._segyio.read_trace(self._file.xfd, traceno, tracecount, buf, trace0, bsz, fmt, samples)
 
     def _writetr(self, traceno, buf):
         self.write_trace(traceno, buf, self._file)
@@ -99,3 +96,8 @@ class Trace:
         """
 
         segyio._segyio.write_trace(segy.xfd, traceno, buf, segy._tr0, segy._bsz, segy._fmt, segy.samples)
+
+    @property
+    def raw(self):
+        """ :rtype: segyio.RawTrace """
+        return RawTrace(self)

--- a/python/segyio/segy.py
+++ b/python/segyio/segy.py
@@ -302,6 +302,21 @@ class SegyFile(object):
             Fill the file with one trace (filled with zeros)::
                 >>> tr = np.zeros(f.samples)
                 >>> f.trace = itertools.repeat(tr)
+
+            For advanced users: sometimes you want to load the entire segy file
+            to memory and apply your own structural manipulations or operations
+            on it. Some segy files are very large and may not fit, in which
+            case this feature will break down. This is an optimisation feature;
+            using it should generally be driven by measurements.
+
+            Read the first 10 traces::
+                >>> f.trace.raw[0:10]
+
+            Read *all* traces to memory::
+                >>> f.trace.raw[:]
+
+            Read every other trace to memory::
+                >>> f.trace.raw[::2]
         """
 
         return Trace(self)

--- a/tests/test_segy.py
+++ b/tests/test_segy.py
@@ -187,6 +187,28 @@ class TestSegy(TestCase):
             for line in f.xline:
                 pass
 
+    def test_traces_raw(self):
+        with segyio.open(self.filename, "r") as f:
+            gen_traces = np.array(map( np.copy, f.trace ), dtype = np.single)
+
+            raw_traces = f.trace.raw[:]
+            self.assertTrue(np.array_equal(gen_traces, raw_traces))
+
+            self.assertEqual(len(gen_traces), f.tracecount)
+            self.assertEqual(len(raw_traces), f.tracecount)
+
+            self.assertEqual(gen_traces[0][49], raw_traces[0][49])
+            self.assertEqual(gen_traces[1][49], f.trace.raw[1][49])
+            self.assertEqual(gen_traces[2][49], raw_traces[2][49])
+
+            self.assertTrue(np.array_equal(f.trace[10], f.trace.raw[10]))
+
+            for raw, gen in itertools.izip(f.trace.raw[::2], f.trace[::2]):
+                self.assertTrue(np.array_equal(raw, gen))
+
+            for raw, gen in itertools.izip(f.trace.raw[::-1], f.trace[::-1]):
+                self.assertTrue(np.array_equal(raw, gen))
+
     def test_read_header(self):
         with segyio.open(self.filename, "r") as f:
             self.assertEqual(1, f.header[0][189])

--- a/tests/test_segyio_c.py
+++ b/tests/test_segyio_c.py
@@ -379,12 +379,12 @@ class _segyioTests(TestCase):
 
         buf = numpy.zeros(25, dtype=numpy.single)
 
-        _segyio.read_trace(f, 0, buf, 0, 100, 1, 25)
+        _segyio.read_trace(f, 0, 25, buf, 0, 100, 1, 25)
 
         self.assertAlmostEqual(buf[10], 1.0, places=4)
         self.assertAlmostEqual(buf[11], 3.1415, places=4)
 
-        _segyio.read_trace(f, 1, buf, 0, 100, 1, 25)
+        _segyio.read_trace(f, 1, 25, buf, 0, 100, 1, 25)
 
         self.assertAlmostEqual(sum(buf), 42.0 * 25, places=4)
 


### PR DESCRIPTION
 Trace.raw mode for eager reading of traces

Adds support for the raw trace sub mode that does eager reading of
traces into an MxN numpy array - a useful feature for segyview and other
visualisation tools when it is known beforehand that the file will fit
in memory.