### PR TITLE
Remove undefined pointer casts

### DIFF
--- a/python/segyio/_segyio.c
+++ b/python/segyio/_segyio.c
@@ -755,11 +755,11 @@ static PyObject *py_read_trace(PyObject *self, PyObject *args) {
     }
 
     int error = 0;
-    char* buf = buffer.buf;
+    float* buf = buffer.buf;
     Py_ssize_t i;
 
-    for( i = 0; error == 0 && i < length; ++i, buf += trace_bsize ) {
-        error = segy_readtrace(p_FILE, start + (i * step), (float*)buf, trace0, trace_bsize);
+    for( i = 0; error == 0 && i < length; ++i, buf += samples ) {
+        error = segy_readtrace(p_FILE, start + (i * step), buf, trace0, trace_bsize);
     }
 
     int conv_error = segy_to_native(format, length * samples, buffer.buf);

--- a/src/segyio/segy.h
+++ b/src/segyio/segy.h
@@ -114,11 +114,11 @@ int segy_writetrace( FILE*,
 
 /* convert to/from native float from segy formats (likely IBM or IEEE) */
 int segy_to_native( int format,
-                    unsigned int size,
+                    int size,
                     float* buf );
 
 int segy_from_native( int format,
-                      unsigned int size,
+                      int size,
                       float* buf );
 
 int segy_read_line( FILE* fp,

--- a/src/segyio/util.h
+++ b/src/segyio/util.h
@@ -10,8 +10,8 @@
 
 void ebcdic2ascii( const char* ebcdic, char* ascii );
 void ascii2ebcdic( const char* ascii, char* ebcdic );
-void ibm2ieee(void* to, const void* from, int len);
-void ieee2ibm(void* to, const void* from, int len);
+void ibm2ieee(void* to, const void* from);
+void ieee2ibm(void* to, const void* from);
 int segy_seek( FILE*, unsigned int, long, unsigned int );
 
 #endif //SEGYIO_UTILS_H

--- a/tests/test_utils.c
+++ b/tests/test_utils.c
@@ -57,9 +57,9 @@ static void check(float f1, double * epsm) {
     unsigned ibm1, ibm2;
 
     frexp(f1, &exp);
-    ieee2ibm(&ibm1, &f1, 1);
-    ibm2ieee(&f2, &ibm1, 1);
-    ieee2ibm(&ibm2, &f2, 1);
+    ieee2ibm(&ibm1, &f1);
+    ibm2ieee(&f2, &ibm1);
+    ieee2ibm(&ibm2, &f2);
 
     assertTrue(memcmp(&ibm1, &ibm2, sizeof ibm1) == 0, "The content of two memory areas were not identical!");
     //printf("Error: %08x <=> %08x\n", *(unsigned*) &ibm1, *(unsigned*) &ibm2);


### PR DESCRIPTION
Restrict aliasing slightly and remove a source of undefined behaviour by
casting float pointers to uint32_t. Reimplements the ieee<->ibm
functions to work on one float at the time without triggering undefined
behaviour.