### PR TITLE
Read/Write line functions are offset aware

### DIFF
--- a/mex/Segy.m
+++ b/mex/Segy.m
@@ -7,29 +7,29 @@ classdef Segy
     methods(Static)
 
         function obj = readInLine(spec, index)
-            obj = segy_read_write_line_mex(spec, index, max(size(spec.crossline_indexes)), spec.inline_indexes, spec.il_stride);
+            obj = segy_read_write_line_mex(spec, index, max(size(spec.crossline_indexes)), spec.inline_indexes, spec.il_stride, spec.offset_count);
         end
 
         function obj = readCrossLine(spec, index)
-            obj = segy_read_write_line_mex(spec, index, max(size(spec.inline_indexes)), spec.crossline_indexes, spec.xl_stride);
+            obj = segy_read_write_line_mex(spec, index, max(size(spec.inline_indexes)), spec.crossline_indexes, spec.xl_stride, spec.offset_count);
         end
 
         function obj = writeCrossLine(spec, data, index)
-            segy_read_write_line_mex(spec, index, max(size(spec.inline_indexes)), spec.crossline_indexes, spec.xl_stride, data);
+            segy_read_write_line_mex(spec, index, max(size(spec.inline_indexes)), spec.crossline_indexes, spec.xl_stride, spec.offset_count, data);
             obj = data;
         end
 
         function obj = writeInLine(spec, data, index)
-            segy_read_write_line_mex(spec, index, max(size(spec.crossline_indexes)), spec.inline_indexes, spec.il_stride, data);
+            segy_read_write_line_mex(spec, index, max(size(spec.crossline_indexes)), spec.inline_indexes, spec.il_stride, spec.offset_count, data);
             obj = data;
         end
 
         function data = get_line(cube, dir, n)
             if strcmpi(dir, 'iline')
-                data = segy_read_write_line_mex(cube, n, max(size(cube.crossline_indexes)), cube.inline_indexes, cube.il_stride);
+                data = segy_read_write_line_mex(cube, n, max(size(cube.crossline_indexes)), cube.inline_indexes, cube.il_stride, cube.offset_count);
 
             elseif strcmpi(dir, 'xline')
-                data = segy_read_write_line_mex(cube, n, max(size(cube.inline_indexes)), cube.crossline_indexes, cube.xl_stride);
+                data = segy_read_write_line_mex(cube, n, max(size(cube.inline_indexes)), cube.crossline_indexes, cube.xl_stride, cube.offset_count);
 
             else
                 error('Only iline and xline are valid directions.');
@@ -38,10 +38,10 @@ classdef Segy
 
         function data = put_line(cube, data, dir, n)
             if strcmpi(dir, 'iline')
-                segy_read_write_line_mex(cube, n, max(size(cube.crossline_indexes)), cube.inline_indexes, cube.il_stride, data);
+                segy_read_write_line_mex(cube, n, max(size(cube.crossline_indexes)), cube.inline_indexes, cube.il_stride, cube.offset_count, data);
 
             elseif strcmpi(dir, 'xline')
-                segy_read_write_line_mex(cube, n, max(size(cube.inline_indexes)), cube.crossline_indexes, cube.xl_stride, data );
+                segy_read_write_line_mex(cube, n, max(size(cube.inline_indexes)), cube.crossline_indexes, cube.xl_stride, cube.offset_count, data );
 
             else
                 error('Only iline and xline are valid directions.');

--- a/mex/segy_read_write_line_mex.c
+++ b/mex/segy_read_write_line_mex.c
@@ -12,10 +12,10 @@ void mexFunction(int nlhs, mxArray *plhs[],
 
     bool read;
 
-    if (nrhs == 5) {
+    if (nrhs == 6) {
         read = true;
     }
-    else if (nrhs == 6) {
+    else if (nrhs == 7) {
         read = false;
     }
     else {
@@ -27,6 +27,7 @@ void mexFunction(int nlhs, mxArray *plhs[],
     const mxArray* mx_line_length = prhs[2];
     const mxArray* mx_line_indexes = prhs[3];
     const mxArray* mx_stride = prhs[4];
+    const mxArray* mx_offsets = prhs[5];
 
     SegySpec spec;
     recreateSpec(&spec,mx_spec);
@@ -41,12 +42,13 @@ void mexFunction(int nlhs, mxArray *plhs[],
     uint32_t line_count = (n>m)? n:m;
 
     uint32_t stride = (uint32_t)mxGetScalar(mx_stride);
+    int32_t offsets = (int32_t)mxGetScalar(mx_offsets);
 
     segy_file* fp;
 
     unsigned int line_trace0;
 
-    int errc = segy_line_trace0( index, line_length, stride, line_indexes, line_count, &line_trace0 );
+    int errc = segy_line_trace0( index, line_length, stride, offsets, line_indexes, line_count, &line_trace0 );
     if (errc != 0) {
         goto CLEANUP;
     }
@@ -60,7 +62,7 @@ void mexFunction(int nlhs, mxArray *plhs[],
         plhs[0] = mxCreateNumericMatrix(spec.sample_count, line_length, mxSINGLE_CLASS, mxREAL);
         float *data_ptr = (float *) mxGetData(plhs[0]);
 
-        errc = segy_read_line( fp, line_trace0, line_length, stride, data_ptr, spec.first_trace_pos, spec.trace_bsize );
+        errc = segy_read_line( fp, line_trace0, line_length, stride, offsets, data_ptr, spec.first_trace_pos, spec.trace_bsize );
         if (errc != 0) {
             goto CLEANUP;
         }
@@ -76,7 +78,7 @@ void mexFunction(int nlhs, mxArray *plhs[],
             goto CLEANUP;
         }
 
-        const mxArray* mx_data = prhs[5];
+        const mxArray* mx_data = prhs[6];
 
         float *data_ptr = (float *) mxGetData(mx_data);
 
@@ -85,7 +87,7 @@ void mexFunction(int nlhs, mxArray *plhs[],
             goto CLEANUP;
         }
 
-        errc = segy_write_line( fp, line_trace0, line_length, stride, data_ptr, spec.first_trace_pos, spec.trace_bsize );
+        errc = segy_write_line( fp, line_trace0, line_length, stride, offsets, data_ptr, spec.first_trace_pos, spec.trace_bsize );
         if (errc != 0) {
             goto CLEANUP;
         }

--- a/python/segyio/_line.py
+++ b/python/segyio/_line.py
@@ -62,11 +62,11 @@ class Line:
             except TypeError:
                 raise TypeError("Must be int or slice")
             else:
-                t0 = self.trace0fn(lineno)
+                t0 = self.trace0fn(lineno, self.segy.offsets)
                 return self.readfn(t0, self.len, self.stride, buf)
 
-    def trace0fn(self, lineno):
-        return segyio._segyio.fread_trace0(lineno, len(self.other_lines), self.stride, self.lines, self.name)
+    def trace0fn(self, lineno, offsets):
+        return segyio._segyio.fread_trace0(lineno, len(self.other_lines), self.stride, offsets, self.lines, self.name)
 
     def __setitem__(self, lineno, val):
         if isinstance(lineno, slice):
@@ -81,7 +81,7 @@ class Line:
 
             return
 
-        t0 = self.trace0fn(lineno)
+        t0 = self.trace0fn(lineno, self.segy.offsets)
         self.writefn(t0, self.len, self.stride, val)
 
     def __len__(self):

--- a/python/segyio/_segyio.c
+++ b/python/segyio/_segyio.c
@@ -696,10 +696,11 @@ static PyObject *py_fread_trace0(PyObject *self, PyObject *args) {
     unsigned int lineno;
     unsigned int other_line_length;
     unsigned int stride;
+    int offsets;
     PyObject *indices_object;
     char *type_name;
 
-    PyArg_ParseTuple(args, "IIIOs", &lineno, &other_line_length, &stride, &indices_object, &type_name);
+    PyArg_ParseTuple(args, "IIIiOs", &lineno, &other_line_length, &stride, &offsets, &indices_object, &type_name);
 
     Py_buffer buffer;
     if (!PyObject_CheckBuffer(indices_object)) {
@@ -710,7 +711,7 @@ static PyObject *py_fread_trace0(PyObject *self, PyObject *args) {
 
     unsigned int trace_no;
     unsigned int linenos_sz = (unsigned int) PyObject_Length(indices_object);
-    int error = segy_line_trace0(lineno, other_line_length, stride, buffer.buf, linenos_sz, &trace_no);
+    int error = segy_line_trace0(lineno, other_line_length, stride, offsets, buffer.buf, linenos_sz, &trace_no);
     PyBuffer_Release( &buffer );
 
     if (error != 0) {
@@ -848,14 +849,19 @@ static PyObject *py_read_line(PyObject *self, PyObject *args) {
     unsigned int line_trace0;
     unsigned int line_length;
     unsigned int stride;
+    int offsets;
     PyObject *buffer_in;
     long trace0;
     unsigned int trace_bsize;
     int format;
     unsigned int samples;
 
-    PyArg_ParseTuple(args, "OIIIOlIiI", &file_capsule, &line_trace0, &line_length, &stride, &buffer_in, &trace0,
-                     &trace_bsize, &format, &samples);
+    PyArg_ParseTuple(args, "OIIIiOlIiI", &file_capsule,
+                                         &line_trace0,
+                                         &line_length, &stride, &offsets,
+                                         &buffer_in,
+                                         &trace0, &trace_bsize,
+                                         &format, &samples);
 
     segy_file *p_FILE = get_FILE_pointer_from_capsule(file_capsule);
 
@@ -868,7 +874,7 @@ static PyObject *py_read_line(PyObject *self, PyObject *args) {
     Py_buffer buffer;
     PyObject_GetBuffer(buffer_in, &buffer, PyBUF_FORMAT | PyBUF_C_CONTIGUOUS | PyBUF_WRITEABLE);
 
-    int error = segy_read_line(p_FILE, line_trace0, line_length, stride, buffer.buf, trace0, trace_bsize);
+    int error = segy_read_line(p_FILE, line_trace0, line_length, stride, offsets, buffer.buf, trace0, trace_bsize);
 
     if (error != 0) {
         PyBuffer_Release( &buffer );

--- a/python/segyio/segy.py
+++ b/python/segyio/segy.py
@@ -373,7 +373,8 @@ class SegyFile(object):
         return self._shape_buffer(shape, buf)
 
     def _fread_line(self, trace0, length, stride, buf):
-        return _segyio.read_line(self.xfd, trace0, length, stride, buf, self._tr0, self._bsz, self._fmt, self.samples)
+        offsets = self.offsets
+        return _segyio.read_line(self.xfd, trace0, length, stride, offsets, buf, self._tr0, self._bsz, self._fmt, self.samples)
 
     @property
     def ilines(self):

--- a/src/segyio/segy.h
+++ b/src/segyio/segy.h
@@ -133,17 +133,19 @@ int segy_read_line( segy_file* fp,
                     unsigned int line_trace0,
                     unsigned int line_length,
                     unsigned int stride,
+                    int offsets,
                     float* buf,
                     long trace0,
                     unsigned int trace_bsize );
 
 int segy_write_line( segy_file* fp,
-                     unsigned int line_trace0,
-                     unsigned int line_length,
-                     unsigned int stride,
-                     float* buf,
-                     long trace0,
-                     unsigned int trace_bsize );
+                    unsigned int line_trace0,
+                    unsigned int line_length,
+                    unsigned int stride,
+                    int offsets,
+                    const float* buf,
+                    long trace0,
+                    unsigned int trace_bsize );
 
 /*
  * Count inlines and crosslines. Use this function to determine how large buffer
@@ -203,8 +205,10 @@ int segy_crossline_indices( segy_file*,
  * Find the first `traceno` of the line `lineno`. `linenos` should be the line
  * indices returned by `segy_inline_indices` or `segy_crossline_indices`. The
  * stride depends on the sorting and is given by `segy_inline_stride` or
- * `segy_crossline_stride`. `line_length` is the length, i.e. traces per line,
- * given by `segy_inline_length` or `segy_crossline_length`.
+ * `segy_crossline_stride`. `offsets` is given by `segy_offsets` function, and
+ * is the number of offsets in this file (1 for post stack data). `line_length`
+ * is the length, i.e. traces per line, given by `segy_inline_length` or
+ * `segy_crossline_length`.
  *
  * To read/write an inline, read `line_length` starting at `traceno`,
  * incrementing `traceno` with `stride` `line_length` times.
@@ -212,6 +216,7 @@ int segy_crossline_indices( segy_file*,
 int segy_line_trace0( unsigned int lineno,
                       unsigned int line_length,
                       unsigned int stride,
+                      int offsets,
                       const unsigned int* linenos,
                       const unsigned int linenos_sz,
                       unsigned int* traceno );

--- a/tests/test_segy.c
+++ b/tests/test_segy.c
@@ -73,7 +73,7 @@ static void test_interpret_file() {
     assertTrue( err == 0, "Failure while reading stride." );
     assertTrue( stride == 1, "Expected inline stride = 1." );
 
-    err = segy_line_trace0( 4, crosslines_sz, stride, inline_indices, inlines_sz, &line_trace0 );
+    err = segy_line_trace0( 4, crosslines_sz, stride, offsets, inline_indices, inlines_sz, &line_trace0 );
     assertTrue( err == 0, "Could not determine 2484's trace0." );
     assertTrue( line_trace0 == 15, "Line 4 should start at traceno 15." );
 
@@ -92,7 +92,7 @@ static void test_interpret_file() {
     assertTrue( err == 0, "Failure while reading stride." );
     assertTrue( stride == 5, "Expected crossline stride = 5." );
 
-    err = segy_line_trace0( 22, crosslines_sz, stride, crossline_indices, inlines_sz, &line_trace0 );
+    err = segy_line_trace0( 22, crosslines_sz, stride, offsets, crossline_indices, inlines_sz, &line_trace0 );
     assertTrue( err == 0, "Could not determine 22's trace0." );
     assertTrue( line_trace0 == 2, "Line 22 should start at traceno 2." );
 
@@ -230,11 +230,11 @@ static void testReadInLine_4(){
       && !segy_count_lines( fp, xl, offsets, &inlines_sz, &crosslines_sz, trace0, trace_bsize )
       && !segy_inline_indices( fp, il, sorting, inlines_sz, crosslines_sz, offsets, inline_indices, trace0, trace_bsize )
       && !segy_inline_stride( sorting, inlines_sz, &stride )
-      && !segy_line_trace0( 4, crosslines_sz, stride, inline_indices, inlines_sz, &line_trace0 );
+      && !segy_line_trace0( 4, crosslines_sz, stride, offsets, inline_indices, inlines_sz, &line_trace0 );
 
     line_length = segy_inline_length(crosslines_sz);
 
-      ok = ok && !segy_read_line( fp, line_trace0, line_length, stride, data, trace0, trace_bsize )
+      ok = ok && !segy_read_line( fp, line_trace0, line_length, stride, offsets, data, trace0, trace_bsize )
       && !segy_to_native( format, inline_length * samples, data );
 
     assertTrue( ok, "Error in setup. "
@@ -305,11 +305,11 @@ static void testReadCrossLine_22(){
       && !segy_count_lines( fp, xl, offsets, &inlines_sz, &crosslines_sz, trace0, trace_bsize )
       && !segy_crossline_indices( fp, xl, sorting, inlines_sz, crosslines_sz, offsets, crossline_indices, trace0, trace_bsize )
       && !segy_crossline_stride( sorting, crosslines_sz, &stride )
-      && !segy_line_trace0( 22, crosslines_sz, stride, crossline_indices, inlines_sz, &line_trace0 );
+      && !segy_line_trace0( 22, crosslines_sz, stride, offsets, crossline_indices, inlines_sz, &line_trace0 );
 
     line_length = segy_crossline_length(inlines_sz);
 
-    ok = ok && !segy_read_line( fp, line_trace0, line_length, stride, data, trace0, trace_bsize )
+    ok = ok && !segy_read_line( fp, line_trace0, line_length, stride, offsets, data, trace0, trace_bsize )
       && !segy_to_native( format, crossline_length * samples, data );
 
     assertTrue( ok, "Error in setup. "
@@ -552,7 +552,7 @@ static void test_error_codes_sans_file() {
     int err;
 
     unsigned int linenos[] = { 0, 1, 2 };
-    err = segy_line_trace0( 10, 3, 1, linenos, 3, NULL );
+    err = segy_line_trace0( 10, 3, 1, 1, linenos, 3, NULL );
     assertTrue( err == SEGY_MISSING_LINE_INDEX,
                 "Found line number that shouldn't exist." );
 

--- a/tests/test_segyio_c.py
+++ b/tests/test_segyio_c.py
@@ -285,21 +285,21 @@ class _segyioTests(TestCase):
         _segyio.init_line_indices(f, metrics, iline_indexes, xline_indexes)
 
         with self.assertRaises(KeyError):
-            _segyio.fread_trace0(0, len(xline_indexes), line_metrics['iline_stride'], iline_indexes, "inline")
+            _segyio.fread_trace0(0, len(xline_indexes), line_metrics['iline_stride'], offset_count, iline_indexes, "inline")
 
         with self.assertRaises(KeyError):
-            _segyio.fread_trace0(2, len(iline_indexes), line_metrics['xline_stride'], xline_indexes, "crossline")
+            _segyio.fread_trace0(2, len(iline_indexes), line_metrics['xline_stride'], offset_count, xline_indexes, "crossline")
 
-        value = _segyio.fread_trace0(1, len(xline_indexes), line_metrics['iline_stride'], iline_indexes, "inline")
+        value = _segyio.fread_trace0(1, len(xline_indexes), line_metrics['iline_stride'], offset_count, iline_indexes, "inline")
         self.assertEqual(value, 0)
 
-        value = _segyio.fread_trace0(2, len(xline_indexes), line_metrics['iline_stride'], iline_indexes, "inline")
+        value = _segyio.fread_trace0(2, len(xline_indexes), line_metrics['iline_stride'], offset_count, iline_indexes, "inline")
         self.assertEqual(value, 5)
 
-        value = _segyio.fread_trace0(21, len(iline_indexes), line_metrics['xline_stride'], xline_indexes, "crossline")
+        value = _segyio.fread_trace0(21, len(iline_indexes), line_metrics['xline_stride'], offset_count, xline_indexes, "crossline")
         self.assertEqual(value, 1)
 
-        value = _segyio.fread_trace0(22, len(iline_indexes), line_metrics['xline_stride'], xline_indexes, "crossline")
+        value = _segyio.fread_trace0(22, len(iline_indexes), line_metrics['xline_stride'], offset_count, xline_indexes, "crossline")
         self.assertEqual(value, 2)
 
         _segyio.close(f)
@@ -425,16 +425,17 @@ class _segyioTests(TestCase):
         samples = metrics['sample_count']
         xline_stride = metrics['xline_stride']
         iline_stride = metrics['iline_stride']
+        offsets = metrics['offset_count']
 
-        xline_trace0 = _segyio.fread_trace0(20, len(iline_idx), xline_stride, xline_idx, "crossline")
-        iline_trace0 = _segyio.fread_trace0(1, len(xline_idx), iline_stride, iline_idx, "inline")
+        xline_trace0 = _segyio.fread_trace0(20, len(iline_idx), xline_stride, offsets, xline_idx, "crossline")
+        iline_trace0 = _segyio.fread_trace0(1, len(xline_idx), iline_stride, offsets, iline_idx, "inline")
 
         buf = numpy.zeros((len(iline_idx), samples), dtype=numpy.single)
 
-        _segyio.read_line(f, xline_trace0, len(iline_idx), xline_stride, buf, tr0, bsz, 1, samples)
+        _segyio.read_line(f, xline_trace0, len(iline_idx), xline_stride, offsets, buf, tr0, bsz, 1, samples)
         self.assertAlmostEqual(sum(sum(buf)), 800.061169624, places=6)
 
-        _segyio.read_line(f, iline_trace0, len(xline_idx), iline_stride, buf, tr0, bsz, 1, samples)
+        _segyio.read_line(f, iline_trace0, len(xline_idx), iline_stride, offsets, buf, tr0, bsz, 1, samples)
         self.assertAlmostEqual(sum(sum(buf)), 305.061146736, places=6)
 
         _segyio.close(f)
@@ -447,16 +448,17 @@ class _segyioTests(TestCase):
         samples = metrics['sample_count']
         xline_stride = metrics['xline_stride']
         iline_stride = metrics['iline_stride']
+        offsets = metrics['offset_count']
 
-        xline_trace0 = _segyio.fread_trace0(20, len(iline_idx), xline_stride, xline_idx, "crossline")
-        iline_trace0 = _segyio.fread_trace0(1, len(xline_idx), iline_stride, iline_idx, "inline")
+        xline_trace0 = _segyio.fread_trace0(20, len(iline_idx), xline_stride, offsets, xline_idx, "crossline")
+        iline_trace0 = _segyio.fread_trace0(1, len(xline_idx), iline_stride, offsets, iline_idx, "inline")
 
         buf = numpy.zeros((len(iline_idx), samples), dtype=numpy.single)
 
-        _segyio.read_line(f, xline_trace0, len(iline_idx), xline_stride, buf, tr0, bsz, 1, samples)
+        _segyio.read_line(f, xline_trace0, len(iline_idx), xline_stride, offsets, buf, tr0, bsz, 1, samples)
         self.assertAlmostEqual(sum(sum(buf)), 800.061169624, places=6)
 
-        _segyio.read_line(f, iline_trace0, len(xline_idx), iline_stride, buf, tr0, bsz, 1, samples)
+        _segyio.read_line(f, iline_trace0, len(xline_idx), iline_stride, offsets, buf, tr0, bsz, 1, samples)
         self.assertAlmostEqual(sum(sum(buf)), 305.061146736, places=6)
 
         _segyio.close(f)
@@ -466,9 +468,9 @@ class _segyioTests(TestCase):
         indices = numpy.asarray(elements, dtype=numpy.uintc)
 
         for index in indices:
-            d = _segyio.fread_trace0(index, 1, 1, indices, "depth")
+            d = _segyio.fread_trace0(index, 1, 1, 1, indices, "depth")
             self.assertEqual(d, index)
 
         with self.assertRaises(KeyError):
-            d = _segyio.fread_trace0(25, 1, 1, indices, "depth")
+            d = _segyio.fread_trace0(25, 1, 1, 1, indices, "depth")
 


### PR DESCRIPTION
Enable support for reading lines in prestack files by letting them know
how much they need to skip (i.e. offset cardinality).

I have not yet been able to run the matlab tests (no licence on this computer), so please run locally or through CI to make sure I didn't miss anything.