### PR TITLE
__repr__ support

### DIFF
--- a/python/segyio/__init__.py
+++ b/python/segyio/__init__.py
@@ -52,6 +52,9 @@ class Enum(object):
                 return k
         return "Unknown Enum"
 
+    def __repr__(self):
+        return str(self)
+
     def __hash__(self):
         return hash(self._value)
 

--- a/python/segyio/__init__.py
+++ b/python/segyio/__init__.py
@@ -63,6 +63,9 @@ class Enum(object):
         else:
             return self._value == o
 
+    def __ne__(self, other):
+        return not self == other
+
     @classmethod
     def enums(cls):
         result = []

--- a/python/segyio/_field.py
+++ b/python/segyio/_field.py
@@ -79,3 +79,10 @@ class Field:
             segyio._segyio.write_traceheader(segy.xfd, traceno, buf, segy._tr0, segy._bsz)
 
         return Field(buf, traceno=traceno, write=wr, field_type=TraceField)
+
+    def __repr__(self):
+        def assigned(x):
+            return x != BinField.Unassigned1 and x != BinField.Unassigned2
+
+        fields = filter(assigned, self._field_type.enums())
+        return self[fields].__repr__()

--- a/python/segyio/_header.py
+++ b/python/segyio/_header.py
@@ -44,6 +44,9 @@ class Header(object):
     def __iter__(self):
         return self[:]
 
+    def __repr__(self):
+        return "Header(traces = {})".format(self.segy.samples)
+
     def readfn(self, t0, length, stride, buf):
         def gen():
             start = t0

--- a/python/segyio/_line.py
+++ b/python/segyio/_line.py
@@ -29,6 +29,9 @@ class Line:
         self.readfn = readfn
         self.writefn = writefn
 
+    def __repr__(self):
+        return "Line(direction = {}, length = {})".format(self.name, self.len)
+
     def _index(self, lineno, offset):
         """ :rtype: int"""
         offs = self.segy.offsets

--- a/python/segyio/_raw_trace.py
+++ b/python/segyio/_raw_trace.py
@@ -17,3 +17,5 @@ class RawTrace(object):
 
         return self.trace._readtr(index, buf)
 
+    def __repr__(self):
+        return self.trace.__repr__() + ".raw"

--- a/python/segyio/_trace.py
+++ b/python/segyio/_trace.py
@@ -62,6 +62,9 @@ class Trace:
     def __iter__(self):
         return self[:]
 
+    def __repr__(self):
+        return "Trace(traces = {}, samples = {})".format(len(self), self._file.samples)
+
     def _trace_buffer(self, buf=None):
         samples = self._file.samples
 

--- a/python/segyio/segy.py
+++ b/python/segyio/segy.py
@@ -813,6 +813,9 @@ class SegyFile(object):
             def __repr__(inner):
                 return "Text(external_headers = {})".format(self.ext_headers)
 
+            def __str__(inner):
+                return '\n'.join(map(''.join, zip(*[iter(inner[0])] * 80)))
+
         return TextHeader()
 
     @property

--- a/python/segyio/segy.py
+++ b/python/segyio/segy.py
@@ -60,6 +60,10 @@ class SegyFile(object):
 
         super(SegyFile, self).__init__()
 
+    def __repr__(self):
+        return "SegyFile('{}', '{}', iline = {}, xline = {})".format(
+                        self._filename, self._mode, self._il, self._xl)
+
     def __enter__(self):
         """Internal.
         :rtype: segyio.segy.SegyFile
@@ -787,6 +791,9 @@ class SegyFile(object):
                     raise IndexError("Textual header %d not in file" % index)
 
                 _segyio.write_textheader(self.xfd, index, val)
+
+            def __repr__(inner):
+                return "Text(external_headers = {})".format(self.ext_headers)
 
         return TextHeader()
 

--- a/python/segyio/segy.py
+++ b/python/segyio/segy.py
@@ -60,6 +60,24 @@ class SegyFile(object):
 
         super(SegyFile, self).__init__()
 
+    def __str__(self):
+        f = "SegyFile {}:".format(self._filename)
+        il =  "  inlines: {} [{}, {}]".format(len(self.ilines), self.ilines[0], self.ilines[-1])
+        xl =  "  crosslines: {} [{}, {}]".format(len(self.xlines), self.xlines[0], self.xlines[-1])
+        tr =  "  traces: {}".format(self.tracecount)
+        sm =  "  samples: {}".format(self.samples)
+        of =  "  offsets: {} [{}, {}]".format(len(self.offsets), self.offsets[0], self.offsets[-1])
+        fmt = "  float representation: {}".format(self.format)
+
+        props = [f, il, xl, tr, sm]
+
+        if len(self.offsets) > 1:
+            props.append(of)
+
+        props.append(fmt)
+        return '\n'.join(props)
+
+
     def __repr__(self):
         return "SegyFile('{}', '{}', iline = {}, xline = {})".format(
                         self._filename, self._mode, self._il, self._xl)


### PR DESCRIPTION
Some simple __repr__ to help developers and researchers using segy interactively.

Demo:
```
Python 2.7.5 (default, Oct 11 2015, 17:47:16) 
[GCC 4.8.3 20140911 (Red Hat 4.8.3-9)] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import segyio
>>> f = segyio.open("tests/test-data/small.sgy")
>>> f
SegyFile('tests/test-data/small.sgy', 'r', iline = 189, xline = 193)
>>> f.header
Header(traces = 50)
>>> f.bin
{JobID: 0, LineNumber: 0, ReelNumber: 0, Traces: 25, AuxTraces: 0, Interval:
4000, IntervalOriginal: 0, Samples: 50, SamplesOriginal: 0, Format: 1,
EnsembleFold: 0, SortingCode: 0, VerticalSum: 0, SweepFrequencyStart: 0,
SweepFrequencyEnd: 0, SweepLength: 0, SEGYRevision: 0, Sweep: 0, SweepChannel:
0, SweepTaperStart: 0, SweepTaperEnd: 0, Taper: 0, CorrelatedTraces: 0,
BinaryGainRecovery: 0, AmplitudeRecovery: 0, MeasurementSystem: 0,
ImpulseSignalPolarity: 0, VibratoryPolarity: 0, TraceFlag: 0, ExtendedHeaders:
0} 
>>> f.header[0]
{TRACE_SEQUENCE_LINE: 0, TRACE_SEQUENCE_FILE: 0, FieldRecord: 0, TraceNumber:
0, EnergySourcePoint: 0, CDP: 0, CDP_TRACE: 0, TraceIdentificationCode: 0,
NSummedTraces: 0, NStackedTraces: 0, DataUse: 0, offset: 1,
ReceiverGroupElevation: 0, SourceSurfaceElevation: 0, SourceDepth: 0,
ReceiverDatumElevation: 0, SourceDatumElevation: 0, SourceWaterDepth: 0,
GroupWaterDepth: 0, ElevationScalar: 0, SourceGroupScalar: 0, SourceX: 0,
SourceY: 0, GroupX: 0, GroupY: 0, CoordinateUnits: 0, WeatheringVelocity: 0,
SubWeatheringVelocity: 0, SourceUpholeTime: 0, GroupUpholeTime: 0,
SourceStaticCorrection: 0, GroupStaticCorrection: 0, TotalStaticApplied: 0,
LagTimeA: 0, LagTimeB: 0, DelayRecordingTime: 0, MuteTimeStart: 0, MuteTimeEND:
0, TRACE_SAMPLE_COUNT: 0, TRACE_SAMPLE_INTERVAL: 0, GainType: 0,
InstrumentGainConstant: 0, InstrumentInitialGain: 0, Correlated: 0,
SweepFrequencyStart: 0, SweepFrequencyEnd: 0, SweepLength: 0, SweepType: 0,
SweepTraceTaperLengthStart: 0, SweepTraceTaperLengthEnd: 0, TaperType: 0,
AliasFilterFrequency: 0, AliasFilterSlope: 0, NotchFilterFrequency: 0,
NotchFilterSlope: 0, LowCutFrequency: 0, HighCutFrequency: 0, LowCutSlope: 0,
HighCutSlope: 0, YearDataRecorded: 0, DayOfYear: 0, HourOfDay: 0, MinuteOfHour:
0, SecondOfMinute: 0, TimeBaseCode: 0, TraceWeightingFactor: 0,
GeophoneGroupNumberRoll1: 0, GeophoneGroupNumberFirstTraceOrigField: 0,
GeophoneGroupNumberLastTraceOrigField: 0, GapSize: 0, OverTravel: 0, CDP_X: 0,
CDP_Y: 0, INLINE_3D: 1, CROSSLINE_3D: 20, ShotPoint: 0, ShotPointScalar: 0,
TraceValueMeasurementUnit: 0, TransductionConstantMantissa: 0,
TransductionConstantPower: 0, TransductionUnit: 0, TraceIdentifier: 0,
ScalarTraceHeader: 0, SourceType: 0, SourceEnergyDirectionMantissa: 0,
SourceEnergyDirectionExponent: 0, SourceMeasurementMantissa: 0,
SourceMeasurementExponent: 0, SourceMeasurementUnit: 0, UnassignedInt1: 0,
UnassignedInt2: 0}
>>> f.trace
Trace(traces = 25, samples = 50)
>>> f.iline
Line(direction = Inline, length = 5)
>>> f.xline
Line(direction = Crossline, length = 5)
>>> f.trace[0]
array([ 1.19999981,  1.20000935,  1.20001984,  1.20002937,  1.20003986,
        1.2000494 ,  1.20005989,  1.20006943,  1.20007992,  1.20008945,
        1.20009995,  1.20010948,  1.20011997,  1.20012951,  1.20014   ,
        1.20014954,  1.20016003,  1.20016956,  1.20018005,  1.20018959,
        1.20019913,  1.20020962,  1.20021915,  1.20022964,  1.20023918,
        1.20024967,  1.20025921,  1.2002697 ,  1.20027924,  1.20028973,
        1.20029926,  1.20030975,  1.20031929,  1.20032978,  1.20033932,
        1.20034981,  1.20035934,  1.20036983,  1.20037937,  1.20038986,
        1.2003994 ,  1.20040989,  1.20041943,  1.20042992,  1.20043945,
        1.20044994,  1.20045948,  1.20046997,  1.20047951,  1.20049   ], dtype=float32)
>>> 

```