### PR TITLE
python.example.write gets private write.sgy file

### DIFF
--- a/mex/test/spec.m
+++ b/mex/test/spec.m
@@ -1,0 +1,88 @@
+% test segyspec
+
+% preconditions 
+filename = 'test-data/small.sgy';
+assert(exist(filename,'file')==2);
+t0 = 1111.0;
+
+%% no such file
+no_such_filename = 'no-such-dir/no-such-file.sgy';
+assert(exist(no_such_filename,'file')~=2);
+try
+    spec = SegySpec(no_such_filename, TraceField.Inline3D, TraceField.Crossline3D, t0);
+    %should not reach here
+    assert(false);
+catch
+    %not actually needed...
+    assert(true);
+end
+
+%% Spec is created
+try
+    spec = SegySpec(filename, TraceField.Inline3D, TraceField.Crossline3D, t0);
+catch
+    %nothing should be caught
+    assert(false);
+end
+
+%% IBM_FLOAT_4_BYTE
+spec = SegySpec(filename, TraceField.Inline3D, TraceField.Crossline3D, t0);
+assert(spec.sample_format == SegySampleFormat.IBM_FLOAT_4_BYTE);
+
+%% filename is set
+spec = SegySpec(filename, TraceField.Inline3D, TraceField.Crossline3D, t0);
+assert(strcmp(spec.filename,filename));
+
+%% trace_sorting_format
+spec = SegySpec(filename, TraceField.Inline3D, TraceField.Crossline3D, t0);
+assert(spec.trace_sorting_format == TraceSortingFormat.iline);
+
+%%offset_count
+spec = SegySpec(filename, TraceField.Inline3D, TraceField.Crossline3D, t0);
+assert(length(spec.offset_count) == 1);
+
+%% sample_indexes
+spec = SegySpec(filename, TraceField.Inline3D, TraceField.Crossline3D, t0);
+sample_indexes = spec.sample_indexes;
+assert(length(sample_indexes) == 50);
+
+for i = 1:length(sample_indexes)
+    t = t0 + (i-1) * 4;
+    assert(sample_indexes(i) == t);
+end
+
+
+%% first_trace_pos
+spec = SegySpec(filename, TraceField.Inline3D, TraceField.Crossline3D, t0);
+first_trace_pos = spec.first_trace_pos;
+assert(first_trace_pos == 3600);
+
+%% il_stride
+spec = SegySpec(filename, TraceField.Inline3D, TraceField.Crossline3D, t0);
+il_stride = spec.il_stride;
+assert(il_stride == 1);
+
+%% xl_stride
+spec = SegySpec(filename, TraceField.Inline3D, TraceField.Crossline3D, t0);
+xl_stride = spec.xl_stride;
+assert(xl_stride == 5);
+
+%% xl_stride
+spec = SegySpec(filename, TraceField.Inline3D, TraceField.Crossline3D, t0);
+trace_bsize = spec.trace_bsize;
+assert(trace_bsize == 50*4);
+
+%% xline
+spec = SegySpec(filename, TraceField.Inline3D, TraceField.Crossline3D, t0);
+assert(length(spec.crossline_indexes)==5)
+for xl = spec.crossline_indexes'
+    assert(xl >= 20 && xl <= 24);
+end
+
+%% iline
+spec = SegySpec(filename, TraceField.Inline3D, TraceField.Crossline3D, t0);
+assert(length(spec.inline_indexes)==5)
+
+for il = spec.inline_indexes'
+    assert(il >= 1 && il <= 5);
+end

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -61,8 +61,11 @@ add_python_test(python.enum.segy    test/segyioenum.py)
 add_python_test(python.tools        test/tools.py)
 add_python_test(python.context      test/context.py)
 
+configure_file(${CMAKE_SOURCE_DIR}/test-data/small.sgy
+               test-data/write.sgy
+               COPYONLY)
 add_python_example(pysegyio python.example.about         examples/about.py test-data/small.sgy INLINE_3D CROSSLINE_3D)
-add_python_example(pysegyio python.example.write         examples/write.py test-data/small.sgy)
+add_python_example(pysegyio python.example.write         examples/write.py test-data/write.sgy)
 add_python_example(pysegyio python.example.makefile      examples/make-file.py test-data/large-file.sgy 20 1 20 1 20)
 add_python_example(pysegyio python.example.makepsfile    examples/make-ps-file.py test-data/small-prestack.sgy 10 1 5 1 4 1 3)
 add_python_example(pysegyio python.example.subcube       examples/copy-sub-cube.py test-data/small.sgy test-data/copy.sgy)


### PR DESCRIPTION
This file used to operate on the shared test-data/small.sgy, which made
tests break on the second run (which isn't picked up by CI).