### PR TITLE
Handle 4G+ files on sizeof(long) == 4 platforms.

### DIFF
--- a/cmake/check_includes.cmake
+++ b/cmake/check_includes.cmake
@@ -1,4 +1,5 @@
 include(CheckIncludeFile)
+include(CheckFunctionExists)
 
 # Portability checks; look for htons function
 check_include_file("netinet/in.h" HAVE_NETINET_IN_H)
@@ -19,4 +20,14 @@ endif()
 check_include_file("sys/mman.h" HAVE_SYS_MMAN_H)
 if (HAVE_SYS_MMAN_H)
     add_definitions("-DHAVE_MMAP")
+endif()
+
+check_include_file("sys/stat.h" HAVE_SYS_STAT_H)
+if (HAVE_SYS_STAT_H)
+    add_definitions("-DHAVE_SYS_STAT_H")
+
+    check_function_exists(_fstati64 HAVE_FSTATI64)
+    if (HAVE_FSTATI64)
+        add_definitions("-DHAVE_FSTATI64")
+    endif ()
 endif()

--- a/lib/src/segyio/util.h
+++ b/lib/src/segyio/util.h
@@ -18,8 +18,8 @@ void ebcdic2ascii( const char* ebcdic, char* ascii );
 void ascii2ebcdic( const char* ascii, char* ebcdic );
 void ibm2ieee(void* to, const void* from);
 void ieee2ibm(void* to, const void* from);
-int segy_seek( struct segy_file_handle*, unsigned int, long, unsigned int );
-long segy_ftell( struct segy_file_handle* );
+int segy_seek( struct segy_file_handle*, int, long, unsigned int );
+long long segy_ftell( struct segy_file_handle* );
 
 #ifdef __cplusplus
 }

--- a/lib/test/segy.c
+++ b/lib/test/segy.c
@@ -1,3 +1,4 @@
+#include <limits.h>
 #include <math.h>
 #include <stdlib.h>
 
@@ -574,13 +575,18 @@ static void test_error_codes_sans_file() {
 static void test_file_size_above_4GB(){
     segy_file* fp = segy_open( "4gbfile", "w+b" );
 
-    unsigned int trace = 5e6;
-    unsigned int trace_bsize = 1e3;
+    unsigned int trace = 5000000;
+    unsigned int trace_bsize = 1000;
+    long long tracesize = trace_bsize + SEGY_TRACE_HEADER_SIZE;
     long trace0 = 0;
-    int err = segy_seek( fp, trace, trace0, trace_bsize);
+
+    int err = segy_seek( fp, trace, trace0, trace_bsize );
     assertTrue(err==0, "");
-    long pos = segy_ftell( fp );
-    assertTrue(pos == (long)trace*((long)trace_bsize+SEGY_TRACE_HEADER_SIZE), "seek overflow");
+
+    long long pos = segy_ftell( fp );
+    assertTrue(pos > (long long)INT_MAX, "pos smaller than INT_MAX. "
+                              "This means there's an overflow somewhere" );
+    assertTrue(pos == trace * tracesize, "seek overflow");
     segy_close(fp);
 }
 


### PR DESCRIPTION
The use of size_t for file positions uses an implicit conversion to
long for calls to fseek and friends. Long is *not* guaranteed to be
64-bit, so this effectively restricts portable support for very large
files.

segy_seek has been rewritten to consider LONG_MAX and doing repeated
relative seeks should the position overflow a long. On most platform
this path should not be taken and optimised out.