### PR TITLE
Remove unsigned in interface

### DIFF
--- a/applications/segyinfo.c
+++ b/applications/segyinfo.c
@@ -51,7 +51,7 @@ int main(int argc, char* argv[]) {
     const int format = segy_format( header );
     const int samples = segy_samples( header );
     const long trace0 = segy_trace0( header );
-    const unsigned int trace_bsize = segy_trace_bsize( samples );
+    const int trace_bsize = segy_trace_bsize( samples );
     int extended_headers;
     err = segy_get_bfield( header, SEGY_BIN_EXT_HEADERS, &extended_headers );
 

--- a/applications/segyinfo.c
+++ b/applications/segyinfo.c
@@ -60,7 +60,7 @@ int main(int argc, char* argv[]) {
         exit( err );
     }
 
-    size_t traces;
+    int traces;
     err = segy_traces( fp, &traces, trace0, trace_bsize );
 
     if( err != 0 ) {
@@ -70,7 +70,7 @@ int main(int argc, char* argv[]) {
 
     printf( "Sample format: %d\n", format );
     printf( "Samples per trace: %d\n", samples );
-    printf( "Traces: %zu\n", traces );
+    printf( "Traces: %d\n", traces );
     printf("Extended text header count: %d\n", extended_headers );
     puts("");
 
@@ -103,7 +103,7 @@ int main(int argc, char* argv[]) {
 
     int min_sample_count = 999999999;
     int max_sample_count = 0;
-    for( int i = 0; i < (int)traces; ++i ) {
+    for( int i = 0; i < traces; ++i ) {
         err = segy_traceheader( fp, i, traceh, trace0, trace_bsize );
         if( err != 0 ) {
             perror( "Unable to read trace" );

--- a/applications/segyinspect.c
+++ b/applications/segyinspect.c
@@ -75,7 +75,7 @@ int main(int argc, char* argv[]) {
     }
 
     const int format = segy_format( header );
-    const unsigned int samples = segy_samples( header );
+    const int samples = segy_samples( header );
     const long trace0 = segy_trace0( header );
     const unsigned int trace_bsize = segy_trace_bsize( samples );
 

--- a/applications/segyinspect.c
+++ b/applications/segyinspect.c
@@ -79,7 +79,7 @@ int main(int argc, char* argv[]) {
     const long trace0 = segy_trace0( header );
     const int trace_bsize = segy_trace_bsize( samples );
 
-    size_t traces;
+    int traces;
     err = segy_traces( fp, &traces, trace0, trace_bsize );
 
     if( err != 0 ) {

--- a/applications/segyinspect.c
+++ b/applications/segyinspect.c
@@ -77,7 +77,7 @@ int main(int argc, char* argv[]) {
     const int format = segy_format( header );
     const int samples = segy_samples( header );
     const long trace0 = segy_trace0( header );
-    const unsigned int trace_bsize = segy_trace_bsize( samples );
+    const int trace_bsize = segy_trace_bsize( samples );
 
     size_t traces;
     err = segy_traces( fp, &traces, trace0, trace_bsize );

--- a/applications/segyinspect.c
+++ b/applications/segyinspect.c
@@ -94,14 +94,14 @@ int main(int argc, char* argv[]) {
         exit( err );
     }
 
-    unsigned int offsets;
+    int offsets;
     err = segy_offsets( fp, il_field, xl_field, traces, &offsets, trace0, trace_bsize );
     if( err != 0 ) {
         perror( "Could not determine offsets" );
         exit( err );
     }
 
-    unsigned int inline_count, crossline_count;
+    int inline_count, crossline_count;
     if( sorting == SEGY_INLINE_SORTING ) {
         err = segy_count_lines( fp, xl_field, offsets, &inline_count, &crossline_count, trace0, trace_bsize );
     } else {
@@ -114,8 +114,8 @@ int main(int argc, char* argv[]) {
         exit( err );
     }
 
-    unsigned int* inline_indices = malloc( sizeof( unsigned int ) * inline_count );
-    unsigned int* crossline_indices = malloc( sizeof( unsigned int ) * crossline_count );
+    int* inline_indices = malloc( sizeof( int ) * inline_count );
+    int* crossline_indices = malloc( sizeof( int ) * crossline_count );
 
     err = segy_inline_indices( fp, il_field, sorting, inline_count, crossline_count, offsets, inline_indices, trace0, trace_bsize );
     if( err != 0 ) {
@@ -143,14 +143,14 @@ int main(int argc, char* argv[]) {
     puts("");
     puts("Crossline indexes:");
 
-    for( unsigned int i = 0; i < crossline_count; i++ ) {
+    for( int i = 0; i < crossline_count; i++ ) {
         printf( "%d ", crossline_indices[i] );
     }
 
     puts("\n");
     puts("Inline indexes:");
 
-    for( unsigned int i = 0; i < inline_count; i++ ) {
+    for( int i = 0; i < inline_count; i++ ) {
         printf( "%d ", inline_indices[i] );
     }
 

--- a/cmake/matlab.cmake
+++ b/cmake/matlab.cmake
@@ -79,9 +79,9 @@ ELSE(WIN32)
     FIND_PROGRAM(MATLAB_MEX
             mex
             PATHS
+            ${MATLAB_ROOT}/bin
             /prog/matlab/R2016B/bin # Statoil location
             /prog/matlab/R2014B/bin # Statoil location
-            ${MATLAB_ROOT}/bin
             /opt/matlab/bin
             /usr/local/matlab/bin
             $ENV{HOME}/matlab/bin

--- a/lib/include/segyio/segy.h
+++ b/lib/include/segyio/segy.h
@@ -80,14 +80,14 @@ int segy_write_textheader( segy_file*, int pos, const char* buf );
 
 /* Read the trace header at `traceno` into `buf`. */
 int segy_traceheader( segy_file*,
-                      unsigned int traceno,
+                      int traceno,
                       char* buf,
                       long trace0,
                       int trace_bsize );
 
 /* Read the trace header at `traceno` into `buf`. */
 int segy_write_traceheader( segy_file*,
-                            unsigned int traceno,
+                            int traceno,
                             const char* buf,
                             long trace0,
                             int trace_bsize );

--- a/lib/include/segyio/segy.h
+++ b/lib/include/segyio/segy.h
@@ -133,13 +133,13 @@ int segy_offset_indices( segy_file*,
  * buffer sent to write must be converted to target float.
  */
 int segy_readtrace( segy_file*,
-                    unsigned int traceno,
+                    int traceno,
                     float* buf,
                     long trace0,
                     int trace_bsize );
 
 int segy_writetrace( segy_file*,
-                     unsigned int traceno,
+                     int traceno,
                      const float* buf,
                      long trace0,
                      int trace_bsize );
@@ -154,7 +154,7 @@ int segy_from_native( int format,
                       float* buf );
 
 int segy_read_line( segy_file* fp,
-                    unsigned int line_trace0,
+                    int line_trace0,
                     unsigned int line_length,
                     unsigned int stride,
                     int offsets,
@@ -163,7 +163,7 @@ int segy_read_line( segy_file* fp,
                     int trace_bsize );
 
 int segy_write_line( segy_file* fp,
-                    unsigned int line_trace0,
+                    int line_trace0,
                     unsigned int line_length,
                     unsigned int stride,
                     int offsets,
@@ -259,7 +259,7 @@ int segy_line_trace0( unsigned int lineno,
                       int offsets,
                       const unsigned int* linenos,
                       const unsigned int linenos_sz,
-                      unsigned int* traceno );
+                      int* traceno );
 
 /*
  * Find the stride needed for an inline/crossline traversal.

--- a/lib/include/segyio/segy.h
+++ b/lib/include/segyio/segy.h
@@ -61,11 +61,15 @@ int segy_get_bfield( const char* binheader, int field, int32_t* f );
 int segy_set_field( char* traceheader, int field, int32_t val );
 int segy_set_bfield( char* binheader, int field, int32_t val );
 
-unsigned segy_trace_bsize( int samples );
+/*
+ * exception: segy_trace_bsize computes the size of the traces in bytes. Cannot
+ * fail.
+ */
+int segy_trace_bsize( int samples );
 /* byte-offset of the first trace header. */
 long segy_trace0( const char* binheader );
 /* number of traces in this file */
-int segy_traces( segy_file*, size_t*, long trace0, unsigned int trace_bsize );
+int segy_traces( segy_file*, size_t*, long trace0, int trace_bsize );
 
 int segy_sample_indexes(segy_file* fp, double* buf, double t0, double dt, size_t count);
 
@@ -79,14 +83,14 @@ int segy_traceheader( segy_file*,
                       unsigned int traceno,
                       char* buf,
                       long trace0,
-                      unsigned int trace_bsize );
+                      int trace_bsize );
 
 /* Read the trace header at `traceno` into `buf`. */
 int segy_write_traceheader( segy_file*,
                             unsigned int traceno,
                             const char* buf,
                             long trace0,
-                            unsigned int trace_bsize );
+                            int trace_bsize );
 
 /*
  * Number of traces in this file. The sorting type will be written to `sorting`
@@ -98,7 +102,7 @@ int segy_sorting( segy_file*,
                   int xl,
                   int* sorting,
                   long trace0,
-                  unsigned int trace_bsize );
+                  int trace_bsize );
 
 /*
  * Number of offsets in this file, written to `offsets`. 1 if a 3D data set, >1
@@ -110,7 +114,7 @@ int segy_offsets( segy_file*,
                   unsigned int traces,
                   unsigned int* offsets,
                   long trace0,
-                  unsigned int trace_bsize );
+                  int trace_bsize );
 
 /*
  * The names of the individual offsets. `out` must be a buffer of
@@ -121,7 +125,7 @@ int segy_offset_indices( segy_file*,
                          int offsets,
                          int* out,
                          long trace0,
-                         unsigned int trace_bsize );
+                         int trace_bsize );
 
 /*
  * read/write traces. Does not manipulate the buffers at all, i.e. in order to
@@ -132,13 +136,13 @@ int segy_readtrace( segy_file*,
                     unsigned int traceno,
                     float* buf,
                     long trace0,
-                    unsigned int trace_bsize );
+                    int trace_bsize );
 
 int segy_writetrace( segy_file*,
                      unsigned int traceno,
                      const float* buf,
                      long trace0,
-                     unsigned int trace_bsize );
+                     int trace_bsize );
 
 /* convert to/from native float from segy formats (likely IBM or IEEE) */
 int segy_to_native( int format,
@@ -156,7 +160,7 @@ int segy_read_line( segy_file* fp,
                     int offsets,
                     float* buf,
                     long trace0,
-                    unsigned int trace_bsize );
+                    int trace_bsize );
 
 int segy_write_line( segy_file* fp,
                     unsigned int line_trace0,
@@ -165,7 +169,7 @@ int segy_write_line( segy_file* fp,
                     int offsets,
                     const float* buf,
                     long trace0,
-                    unsigned int trace_bsize );
+                    int trace_bsize );
 
 /*
  * Count inlines and crosslines. Use this function to determine how large buffer
@@ -185,7 +189,7 @@ int segy_count_lines( segy_file*,
                       unsigned int* l1out,
                       unsigned int* l2out,
                       long trace0,
-                      unsigned int trace_bsize );
+                      int trace_bsize );
 
 /*
  * Alternative interface for segy_count_lines. If you have information about
@@ -201,7 +205,7 @@ int segy_lines_count( segy_file*,
                       int* il_count,
                       int* xl_count,
                       long trace0,
-                      unsigned int trace_bsize );
+                      int trace_bsize );
 /*
  * Find the `line_length` for the inlines. Assumes all inlines, crosslines and
  * traces don't vary in length.
@@ -225,7 +229,7 @@ int segy_inline_indices( segy_file*,
                          unsigned int offsets,
                          unsigned int* buf,
                          long trace0,
-                         unsigned int trace_bsize );
+                         int trace_bsize );
 
 int segy_crossline_indices( segy_file*,
                             int xl,
@@ -235,7 +239,7 @@ int segy_crossline_indices( segy_file*,
                             unsigned int offsets,
                             unsigned int* buf,
                             long trace0,
-                            unsigned int trace_bsize );
+                            int trace_bsize );
 
 /*
  * Find the first `traceno` of the line `lineno`. `linenos` should be the line

--- a/lib/include/segyio/segy.h
+++ b/lib/include/segyio/segy.h
@@ -48,7 +48,11 @@ int segy_close( segy_file* );
 unsigned int segy_binheader_size();
 int segy_binheader( segy_file*, char* buf );
 int segy_write_binheader( segy_file*, const char* buf );
-unsigned int segy_samples( const char* binheader );
+/*
+ * exception: the int returned is the number of samples (the segy standard only
+ * allocates 2 octets for this, so it comfortably sits inside an int
+ */
+int segy_samples( const char* binheader );
 int segy_sample_interval( segy_file*, double* dt);
 /* exception: the int returned is an enum, SEGY_SORTING, not an error code */
 int segy_format( const char* binheader );
@@ -57,7 +61,7 @@ int segy_get_bfield( const char* binheader, int field, int32_t* f );
 int segy_set_field( char* traceheader, int field, int32_t val );
 int segy_set_bfield( char* binheader, int field, int32_t val );
 
-unsigned segy_trace_bsize( unsigned int samples );
+unsigned segy_trace_bsize( int samples );
 /* byte-offset of the first trace header. */
 long segy_trace0( const char* binheader );
 /* number of traces in this file */

--- a/lib/include/segyio/segy.h
+++ b/lib/include/segyio/segy.h
@@ -112,7 +112,7 @@ int segy_offsets( segy_file*,
                   int il,
                   int xl,
                   int traces,
-                  unsigned int* offsets,
+                  int* offsets,
                   long trace0,
                   int trace_bsize );
 
@@ -155,8 +155,8 @@ int segy_from_native( int format,
 
 int segy_read_line( segy_file* fp,
                     int line_trace0,
-                    unsigned int line_length,
-                    unsigned int stride,
+                    int line_length,
+                    int stride,
                     int offsets,
                     float* buf,
                     long trace0,
@@ -164,8 +164,8 @@ int segy_read_line( segy_file* fp,
 
 int segy_write_line( segy_file* fp,
                     int line_trace0,
-                    unsigned int line_length,
-                    unsigned int stride,
+                    int line_length,
+                    int stride,
                     int offsets,
                     const float* buf,
                     long trace0,
@@ -185,9 +185,9 @@ int segy_write_line( segy_file* fp,
  */
 int segy_count_lines( segy_file*,
                       int field,
-                      unsigned int offsets,
-                      unsigned int* l1out,
-                      unsigned int* l2out,
+                      int offsets,
+                      int* l1out,
+                      int* l2out,
                       long trace0,
                       int trace_bsize );
 
@@ -209,13 +209,15 @@ int segy_lines_count( segy_file*,
 /*
  * Find the `line_length` for the inlines. Assumes all inlines, crosslines and
  * traces don't vary in length.
- * *
+ *
  * `inline_count` and `crossline_count` are the two values obtained with
  * `segy_count_lines`.
+ *
+ * These functions cannot fail and return the length, not an error code.
  */
-unsigned int segy_inline_length(unsigned int crossline_count);
+int segy_inline_length(int crossline_count);
 
-unsigned int segy_crossline_length(unsigned int inline_count);
+int segy_crossline_length(int inline_count);
 
 /*
  * Find the indices of the inlines and write to `buf`. `offsets` are the number
@@ -224,20 +226,20 @@ unsigned int segy_crossline_length(unsigned int inline_count);
 int segy_inline_indices( segy_file*,
                          int il,
                          int sorting,
-                         unsigned int inline_count,
-                         unsigned int crossline_count,
-                         unsigned int offsets,
-                         unsigned int* buf,
+                         int inline_count,
+                         int crossline_count,
+                         int offsets,
+                         int* buf,
                          long trace0,
                          int trace_bsize );
 
 int segy_crossline_indices( segy_file*,
                             int xl,
                             int sorting,
-                            unsigned int inline_count,
-                            unsigned int crossline_count,
-                            unsigned int offsets,
-                            unsigned int* buf,
+                            int inline_count,
+                            int crossline_count,
+                            int offsets,
+                            int* buf,
                             long trace0,
                             int trace_bsize );
 
@@ -253,24 +255,24 @@ int segy_crossline_indices( segy_file*,
  * To read/write an inline, read `line_length` starting at `traceno`,
  * incrementing `traceno` with `stride` `line_length` times.
  */
-int segy_line_trace0( unsigned int lineno,
-                      unsigned int line_length,
-                      unsigned int stride,
+int segy_line_trace0( int lineno,
+                      int line_length,
+                      int stride,
                       int offsets,
-                      const unsigned int* linenos,
-                      const unsigned int linenos_sz,
+                      const int* linenos,
+                      int linenos_sz,
                       int* traceno );
 
 /*
  * Find the stride needed for an inline/crossline traversal.
  */
 int segy_inline_stride( int sorting,
-                        unsigned int inline_count,
-                        unsigned int* stride );
+                        int inline_count,
+                        int* stride );
 
 int segy_crossline_stride( int sorting,
-                           unsigned int crossline_count,
-                           unsigned int* stride );
+                           int crossline_count,
+                           int* stride );
 
 typedef enum {
     SEGY_TR_SEQ_LINE                = 1,

--- a/lib/include/segyio/segy.h
+++ b/lib/include/segyio/segy.h
@@ -76,7 +76,7 @@ int segy_sample_indexes(segy_file* fp, double* buf, double t0, double dt, size_t
 /* text header operations */
 int segy_read_textheader( segy_file*, char *buf);
 int segy_textheader_size();
-int segy_write_textheader( segy_file*, unsigned int pos, const char* buf );
+int segy_write_textheader( segy_file*, int pos, const char* buf );
 
 /* Read the trace header at `traceno` into `buf`. */
 int segy_traceheader( segy_file*,

--- a/lib/include/segyio/segy.h
+++ b/lib/include/segyio/segy.h
@@ -69,7 +69,7 @@ int segy_trace_bsize( int samples );
 /* byte-offset of the first trace header. */
 long segy_trace0( const char* binheader );
 /* number of traces in this file */
-int segy_traces( segy_file*, size_t*, long trace0, int trace_bsize );
+int segy_traces( segy_file*, int*, long trace0, int trace_bsize );
 
 int segy_sample_indexes(segy_file* fp, double* buf, double t0, double dt, size_t count);
 
@@ -111,7 +111,7 @@ int segy_sorting( segy_file*,
 int segy_offsets( segy_file*,
                   int il,
                   int xl,
-                  unsigned int traces,
+                  int traces,
                   unsigned int* offsets,
                   long trace0,
                   int trace_bsize );

--- a/lib/include/segyio/segy.h
+++ b/lib/include/segyio/segy.h
@@ -53,7 +53,7 @@ int segy_write_binheader( segy_file*, const char* buf );
  * allocates 2 octets for this, so it comfortably sits inside an int
  */
 int segy_samples( const char* binheader );
-int segy_sample_interval( segy_file*, double* dt);
+int segy_sample_interval( segy_file*, float* dt );
 /* exception: the int returned is an enum, SEGY_SORTING, not an error code */
 int segy_format( const char* binheader );
 int segy_get_field( const char* traceheader, int field, int32_t* f );
@@ -71,7 +71,11 @@ long segy_trace0( const char* binheader );
 /* number of traces in this file */
 int segy_traces( segy_file*, int*, long trace0, int trace_bsize );
 
-int segy_sample_indexes(segy_file* fp, double* buf, double t0, double dt, size_t count);
+int segy_sample_indices( segy_file*,
+                         float t0,
+                         float dt,
+                         int count,
+                         float* buf );
 
 /* text header operations */
 int segy_read_textheader( segy_file*, char *buf);

--- a/lib/src/segy.c
+++ b/lib/src/segy.c
@@ -1077,7 +1077,7 @@ static int skip_traceheader( segy_file* fp ) {
 }
 
 int segy_readtrace( segy_file* fp,
-                    unsigned int traceno,
+                    int traceno,
                     float* buf,
                     long trace0,
                     int trace_bsize ) {
@@ -1104,7 +1104,7 @@ int segy_readtrace( segy_file* fp,
 }
 
 int segy_writetrace( segy_file* fp,
-                     unsigned int traceno,
+                     int traceno,
                      const float* buf,
                      long trace0,
                      int trace_bsize ) {
@@ -1182,10 +1182,10 @@ int segy_from_native( int format,
  * Determine the position of the element `x` in `xs`.
  * Returns -1 if the value cannot be found
  */
-static long index_of( unsigned int x,
-                      const unsigned int* xs,
-                      unsigned int sz ) {
-    for( unsigned int i = 0; i < sz; i++ ) {
+static int index_of( int x,
+                     const unsigned int* xs,
+                     int sz ) {
+    for( int i = 0; i < sz; i++ ) {
         if( xs[i] == x )
             return i;
     }
@@ -1206,7 +1206,7 @@ static long index_of( unsigned int x,
  * segy_readtrace returns.
  */
 int segy_read_line( segy_file* fp,
-                    unsigned int line_trace0,
+                    int line_trace0,
                     unsigned int line_length,
                     unsigned int stride,
                     int offsets,
@@ -1240,7 +1240,7 @@ int segy_read_line( segy_file* fp,
  * segy_readtrace returns.
  */
 int segy_write_line( segy_file* fp,
-                     unsigned int line_trace0,
+                     int line_trace0,
                      unsigned int line_length,
                      unsigned int stride,
                      int offsets,
@@ -1269,9 +1269,9 @@ int segy_line_trace0( unsigned int lineno,
                       int offsets,
                       const unsigned int* linenos,
                       const unsigned int linenos_sz,
-                      unsigned int* traceno ) {
+                      int* traceno ) {
 
-    long index = index_of( lineno, linenos, linenos_sz );
+    int index = index_of( lineno, linenos, linenos_sz );
 
     if( index < 0 ) return SEGY_MISSING_LINE_INDEX;
 

--- a/lib/src/segy.c
+++ b/lib/src/segy.c
@@ -65,14 +65,14 @@ static unsigned char e2a[256] = {
 
 void ebcdic2ascii( const char* ebcdic, char* ascii ) {
     while( *ebcdic != '\0' )
-        *ascii++ = e2a[ (unsigned char) *ebcdic++ ];
+        *ascii++ = (char)e2a[ (unsigned char) *ebcdic++ ];
 
     *ascii = '\0';
 }
 
 void ascii2ebcdic( const char* ascii, char* ebcdic ) {
     while (*ascii != '\0')
-        *ebcdic++ = a2e[(unsigned char) *ascii++];
+        *ebcdic++ = (char)a2e[(unsigned char) *ascii++];
 
     *ebcdic = '\0';
 }

--- a/lib/src/segy.c
+++ b/lib/src/segy.c
@@ -79,7 +79,7 @@ void ascii2ebcdic( const char* ascii, char* ebcdic ) {
 
 void ibm2ieee( void* to, const void* from ) {
     uint32_t fr;      /* fraction */
-    register int exp; /* exponent */
+    int exp;          /* exponent */
     uint32_t sgn;     /* sign */
 
     memcpy( &fr, from, sizeof( uint32_t ) );
@@ -127,7 +127,7 @@ done:
 
 void ieee2ibm( void* to, const void* from ) {
     uint32_t fr;      /* fraction */
-    register int exp; /* exponent */
+    int exp;          /* exponent */
     uint32_t sgn;     /* sign */
 
     /* split into sign, exponent, and fraction */

--- a/lib/src/segy.c
+++ b/lib/src/segy.c
@@ -681,10 +681,10 @@ int segy_traces( segy_file* fp,
     return SEGY_OK;
 }
 
-int segy_sample_interval( segy_file* fp, double* dt) {
+int segy_sample_interval( segy_file* fp, float* dt ) {
 
     char bin_header[ SEGY_BINARY_HEADER_SIZE ];
-    char trace_header[SEGY_TRACE_HEADER_SIZE];
+    char trace_header[ SEGY_TRACE_HEADER_SIZE ];
 
     int err = segy_binheader( fp, bin_header );
     if (err != 0) {
@@ -725,19 +725,22 @@ int segy_sample_interval( segy_file* fp, double* dt) {
 
 }
 
-int segy_sample_indexes( segy_file* fp, double* buf, double t0, double dt, size_t count) {
+int segy_sample_indices( segy_file* fp,
+                         float t0,
+                         float dt,
+                         int count,
+                         float* buf ) {
 
     int err = segy_sample_interval(fp, &dt);
     if (err != 0) {
         return err;
     }
 
-    for (size_t i = 0; i < count; i++) {
+    for( int i = 0; i < count; i++ ) {
         buf[i] = t0 + i * dt;
     }
 
-    return 0;
-
+    return SEGY_OK;
 }
 
 /*

--- a/lib/src/segy.c
+++ b/lib/src/segy.c
@@ -611,7 +611,7 @@ int segy_seek( segy_file* fp,
 }
 
 int segy_traceheader( segy_file* fp,
-                      unsigned int traceno,
+                      int traceno,
                       char* buf,
                       long trace0,
                       int trace_bsize ) {
@@ -633,7 +633,7 @@ int segy_traceheader( segy_file* fp,
 }
 
 int segy_write_traceheader( segy_file* fp,
-                            unsigned int traceno,
+                            int traceno,
                             const char* buf,
                             long trace0,
                             int trace_bsize ) {

--- a/lib/src/segy.c
+++ b/lib/src/segy.c
@@ -1342,9 +1342,11 @@ int segy_read_textheader( segy_file* fp, char *buf) { //todo: Missing position/i
     return SEGY_OK;
 }
 
-int segy_write_textheader( segy_file* fp, unsigned int pos, const char* buf ) {
+int segy_write_textheader( segy_file* fp, int pos, const char* buf ) {
     int err;
     char mbuf[ SEGY_TEXT_HEADER_SIZE + 1 ];
+
+    if( pos < 0 ) return SEGY_INVALID_ARGS;
 
     // TODO: reconsider API, allow non-zero terminated strings
     ascii2ebcdic( buf, mbuf );

--- a/lib/src/segy.c
+++ b/lib/src/segy.c
@@ -661,7 +661,7 @@ int segy_write_traceheader( segy_file* fp,
  * This function assumes that *all traces* are of the same size.
  */
 int segy_traces( segy_file* fp,
-                 size_t* traces,
+                 int* traces,
                  long trace0,
                  int trace_bsize ) {
 
@@ -778,10 +778,9 @@ int segy_sorting( segy_file* fp,
     segy_get_field( traceheader, xl, &xl0 );
     segy_get_field( traceheader, SEGY_TR_OFFSET, &off0 );
 
-    size_t traces_size_t;
-    err = segy_traces( fp, &traces_size_t, trace0, trace_bsize );
+    int traces;
+    err = segy_traces( fp, &traces, trace0, trace_bsize );
     if( err != 0 ) return err;
-    const int traces = traces_size_t;
     int traceno = 1;
 
     do {
@@ -824,7 +823,7 @@ int segy_sorting( segy_file* fp,
 int segy_offsets( segy_file* fp,
                   int il,
                   int xl,
-                  unsigned int traces,
+                  int traces,
                   unsigned int* out,
                   long trace0,
                   int trace_bsize ) {
@@ -966,7 +965,7 @@ int segy_count_lines( segy_file* fp,
     err = count_lines( fp, field, offsets, &l2count, trace0, trace_bsize );
     if( err != 0 ) return err;
 
-    size_t traces;
+    int traces;
     err = segy_traces( fp, &traces, trace0, trace_bsize );
     if( err != 0 ) return err;
 
@@ -1031,13 +1030,8 @@ int segy_inline_indices( segy_file* fp,
                          unsigned int* buf,
                          long trace0,
                          int trace_bsize) {
-    int err;
 
     if( sorting == SEGY_INLINE_SORTING ) {
-        size_t traces;
-        err = segy_traces( fp, &traces, trace0, trace_bsize );
-        if( err != 0 ) return err;
-
         unsigned int stride = crossline_count * offsets;
         return segy_line_indices( fp, il, 0, stride, inline_count, buf, trace0, trace_bsize );
     }
@@ -1059,17 +1053,11 @@ int segy_crossline_indices( segy_file* fp,
                             long trace0,
                             int trace_bsize ) {
 
-    int err;
-
     if( sorting == SEGY_INLINE_SORTING ) {
         return segy_line_indices( fp, xl, 0, offsets, crossline_count, buf, trace0, trace_bsize );
     }
 
     if( sorting == SEGY_CROSSLINE_SORTING ) {
-        size_t traces;
-        err = segy_traces( fp, &traces, trace0, trace_bsize );
-        if( err != 0 ) return err;
-
         unsigned int stride = inline_count * offsets;
         return segy_line_indices( fp, xl, 0, stride, crossline_count, buf, trace0, trace_bsize );
     }

--- a/lib/src/segy.c
+++ b/lib/src/segy.c
@@ -484,12 +484,12 @@ static int set_field( char* header, const int* table, int field, int32_t val ) {
 
     switch( bsize ) {
         case 4:
-            buf32 = htonl( val );
+            buf32 = htonl( (uint32_t)val );
             memcpy( header + (field - 1), &buf32, sizeof( buf32 ) );
             return SEGY_OK;
 
         case 2:
-            buf16 = htons( val );
+            buf16 = htons( (uint16_t)val );
             memcpy( header + (field - 1), &buf16, sizeof( buf16 ) );
             return SEGY_OK;
 

--- a/lib/src/segy.c
+++ b/lib/src/segy.c
@@ -551,13 +551,13 @@ int segy_format( const char* buf ) {
     return format;
 }
 
-unsigned int segy_samples( const char* buf ) {
+int segy_samples( const char* buf ) {
     int32_t samples;
     segy_get_bfield( buf, SEGY_BIN_SAMPLES, &samples );
-    return (unsigned int) samples;
+    return samples;
 }
 
-unsigned int segy_trace_bsize( unsigned int samples ) {
+unsigned int segy_trace_bsize( int samples ) {
     /* Hard four-byte float assumption */
     return samples * 4;
 }
@@ -689,7 +689,7 @@ int segy_sample_interval( segy_file* fp, double* dt) {
     }
 
     const long trace0 = segy_trace0( bin_header );
-    unsigned int samples = segy_samples( bin_header );
+    int samples = segy_samples( bin_header );
     const size_t trace_bsize = segy_trace_bsize( samples );
 
     err = segy_traceheader(fp, 0, trace_header, trace0, trace_bsize);

--- a/lib/src/segy.def
+++ b/lib/src/segy.def
@@ -17,7 +17,7 @@ segy_set_bfield
 segy_trace_bsize
 segy_trace0
 segy_traces
-segy_sample_indexes
+segy_sample_indices
 segy_read_textheader
 segy_textheader_size
 segy_write_textheader

--- a/lib/src/segyio/util.h
+++ b/lib/src/segyio/util.h
@@ -18,7 +18,7 @@ void ebcdic2ascii( const char* ebcdic, char* ascii );
 void ascii2ebcdic( const char* ascii, char* ebcdic );
 void ibm2ieee(void* to, const void* from);
 void ieee2ibm(void* to, const void* from);
-int segy_seek( struct segy_file_handle*, int, long, unsigned int );
+int segy_seek( struct segy_file_handle*, unsigned int, long, int );
 long long segy_ftell( struct segy_file_handle* );
 
 #ifdef __cplusplus

--- a/lib/src/segyio/util.h
+++ b/lib/src/segyio/util.h
@@ -18,7 +18,7 @@ void ebcdic2ascii( const char* ebcdic, char* ascii );
 void ascii2ebcdic( const char* ascii, char* ebcdic );
 void ibm2ieee(void* to, const void* from);
 void ieee2ibm(void* to, const void* from);
-int segy_seek( struct segy_file_handle*, unsigned int, long, int );
+int segy_seek( struct segy_file_handle*, int, long, int );
 long long segy_ftell( struct segy_file_handle* );
 
 #ifdef __cplusplus

--- a/lib/test/segy.c
+++ b/lib/test/segy.c
@@ -34,7 +34,7 @@ static void test_interpret_file() {
     assertTrue( trace0 == 3600,
                 "Wrong byte offset of the first trace header. Expected 3600." );
 
-    const unsigned int samples = segy_samples( header );
+    const int samples = segy_samples( header );
     assertTrue( samples == 50, "Expected 350 samples per trace." );
 
     const size_t trace_bsize = segy_trace_bsize( samples );
@@ -221,7 +221,7 @@ static void testReadInLine_4(){
     segy_file* fp = segy_open( file, "rb" );
     assertTrue( 0 == segy_binheader( fp, header ), "Could not read header" );
     const long trace0 = segy_trace0( header );
-    const unsigned int samples = segy_samples( header );
+    const int samples = segy_samples( header );
     const size_t trace_bsize = segy_trace_bsize( samples );
     const int format = segy_format( header );
 
@@ -255,7 +255,7 @@ static void testReadInLine_4(){
     assertClose(4.20049f, data[samples-1], 0.0001f);
 
     //middle xline
-    size_t middle_line = 2;
+    int middle_line = 2;
     //first sample
     assertClose(4.22f, data[samples*middle_line+0], 0.0001);
     //middle sample
@@ -264,7 +264,7 @@ static void testReadInLine_4(){
     assertClose(4.22049f, data[samples*middle_line+samples-1], 0.0001);
 
     //last xline
-    size_t last_line = (crosslines_sz-1);
+    int last_line = (crosslines_sz-1);
     //first sample
     assertClose(4.24f, data[samples*last_line+0], 0);
     //middle sample
@@ -296,7 +296,7 @@ static void testReadCrossLine_22(){
     segy_file* fp = segy_open( file, "rb" );
     assertTrue( 0 == segy_binheader( fp, header ), "Could not read header" );
     const long trace0 = segy_trace0( header );
-    const unsigned int samples = segy_samples( header );
+    const int samples = segy_samples( header );
     const size_t trace_bsize = segy_trace_bsize( samples );
     const int format = segy_format( header );
 
@@ -330,7 +330,7 @@ static void testReadCrossLine_22(){
     assertClose(1.22049f, data[samples-1], 0.0001);
 
     //middle inline
-    size_t middle_line = 2;
+    int middle_line = 2;
     //first sample
     assertClose(3.22f, data[samples*middle_line+0], 0.0001);
     //middle sample
@@ -339,7 +339,7 @@ static void testReadCrossLine_22(){
     assertClose(3.22049f, data[samples*middle_line+samples-1], 0.0001);
 
     //last inline
-    size_t last_line = (line_length-1);
+    int last_line = (line_length-1);
     //first sample
     assertClose(5.22f, data[samples*last_line+0], 0.0001);
     //middle sample
@@ -366,7 +366,7 @@ static void test_modify_trace_header() {
     err = segy_binheader( fp, bheader );
     assertTrue( err == 0, "Could not read header" );
     const long trace0 = segy_trace0( bheader );
-    const unsigned int samples = segy_samples( bheader );
+    const int samples = segy_samples( bheader );
     const size_t trace_bsize = segy_trace_bsize( samples );
 
     char traceh[ SEGY_TRACE_HEADER_SIZE ];
@@ -470,7 +470,7 @@ static void test_trace_header_errors() {
     char binheader[ SEGY_BINARY_HEADER_SIZE ];
     err = segy_binheader( fp, binheader );
     assertTrue( err == 0, "Could not read binary header." );
-    const unsigned samples = segy_samples( binheader );
+    const int samples = segy_samples( binheader );
     const unsigned bsize = segy_trace_bsize( samples );
     const long trace0 = segy_trace0( binheader );
 
@@ -508,7 +508,7 @@ static void test_file_error_codes() {
     assertTrue( err == SEGY_FSEEK_ERROR,
                 "Could read binary header from invalid file." );
 
-    const unsigned samples = segy_samples( binheader );
+    const int samples = segy_samples( binheader );
     const unsigned trace_bsize = segy_trace_bsize( samples );
     const long trace0 = segy_trace0( binheader );
 

--- a/lib/test/segy.c
+++ b/lib/test/segy.c
@@ -37,7 +37,7 @@ static void test_interpret_file() {
     const int samples = segy_samples( header );
     assertTrue( samples == 50, "Expected 350 samples per trace." );
 
-    const size_t trace_bsize = segy_trace_bsize( samples );
+    const int trace_bsize = segy_trace_bsize( samples );
     assertTrue( trace_bsize == 50 * 4,
                 "Wrong trace byte size. Expected samples * 4-byte float." );
 
@@ -222,7 +222,7 @@ static void testReadInLine_4(){
     assertTrue( 0 == segy_binheader( fp, header ), "Could not read header" );
     const long trace0 = segy_trace0( header );
     const int samples = segy_samples( header );
-    const size_t trace_bsize = segy_trace_bsize( samples );
+    const int trace_bsize = segy_trace_bsize( samples );
     const int format = segy_format( header );
 
     unsigned int inline_indices[ 5 ];
@@ -297,7 +297,7 @@ static void testReadCrossLine_22(){
     assertTrue( 0 == segy_binheader( fp, header ), "Could not read header" );
     const long trace0 = segy_trace0( header );
     const int samples = segy_samples( header );
-    const size_t trace_bsize = segy_trace_bsize( samples );
+    const int trace_bsize = segy_trace_bsize( samples );
     const int format = segy_format( header );
 
     unsigned int crossline_indices[ 5 ];
@@ -367,7 +367,7 @@ static void test_modify_trace_header() {
     assertTrue( err == 0, "Could not read header" );
     const long trace0 = segy_trace0( bheader );
     const int samples = segy_samples( bheader );
-    const size_t trace_bsize = segy_trace_bsize( samples );
+    const int trace_bsize = segy_trace_bsize( samples );
 
     char traceh[ SEGY_TRACE_HEADER_SIZE ];
     err = segy_traceheader( fp, 0, traceh, trace0, trace_bsize );
@@ -471,7 +471,7 @@ static void test_trace_header_errors() {
     err = segy_binheader( fp, binheader );
     assertTrue( err == 0, "Could not read binary header." );
     const int samples = segy_samples( binheader );
-    const unsigned bsize = segy_trace_bsize( samples );
+    const int bsize = segy_trace_bsize( samples );
     const long trace0 = segy_trace0( binheader );
 
     char header[ SEGY_TRACE_HEADER_SIZE ];
@@ -509,7 +509,7 @@ static void test_file_error_codes() {
                 "Could read binary header from invalid file." );
 
     const int samples = segy_samples( binheader );
-    const unsigned trace_bsize = segy_trace_bsize( samples );
+    const int trace_bsize = segy_trace_bsize( samples );
     const long trace0 = segy_trace0( binheader );
 
     char header[ SEGY_TRACE_HEADER_SIZE ];
@@ -575,8 +575,8 @@ static void test_error_codes_sans_file() {
 static void test_file_size_above_4GB(){
     segy_file* fp = segy_open( "4gbfile", "w+b" );
 
-    unsigned int trace = 5000000;
-    unsigned int trace_bsize = 1000;
+    int trace = 5000000;
+    int trace_bsize = 1000;
     long long tracesize = trace_bsize + SEGY_TRACE_HEADER_SIZE;
     long trace0 = 0;
 

--- a/lib/test/segy.c
+++ b/lib/test/segy.c
@@ -17,7 +17,7 @@ static void test_interpret_file() {
     int err;
     char header[ SEGY_BINARY_HEADER_SIZE ];
     int sorting;
-    size_t traces;
+    int traces;
     unsigned int inlines_sz, crosslines_sz;
     unsigned int offsets, stride;
     unsigned int line_trace0, line_length;
@@ -208,7 +208,7 @@ static void testReadInLine_4(){
     const char *file = "test-data/small.sgy";
 
     int sorting;
-    size_t traces;
+    int traces;
     unsigned int inlines_sz, crosslines_sz;
     unsigned int offsets, stride;
     unsigned int line_trace0, line_length;
@@ -283,7 +283,7 @@ static void testReadCrossLine_22(){
     const char *file = "test-data/small.sgy";
 
     int sorting;
-    size_t traces;
+    int traces;
     unsigned int inlines_sz, crosslines_sz;
     unsigned int offsets, stride;
     unsigned int line_trace0, line_length;
@@ -535,7 +535,7 @@ static void test_file_error_codes() {
     err = segy_read_textheader(fp, NULL);
     assertTrue( err == SEGY_FSEEK_ERROR, "Could seek in invalid file." );
 
-    size_t traces;
+    int traces;
     err = segy_traces( fp, &traces, 3600, 350 );
     assertTrue( err == SEGY_FSEEK_ERROR, "Could seek in invalid file." );
 

--- a/lib/test/segy.c
+++ b/lib/test/segy.c
@@ -18,9 +18,9 @@ static void test_interpret_file() {
     char header[ SEGY_BINARY_HEADER_SIZE ];
     int sorting;
     int traces;
-    unsigned int inlines_sz, crosslines_sz;
-    unsigned int offsets, stride;
-    unsigned int line_trace0, line_length;
+    int inlines_sz, crosslines_sz;
+    int offsets, stride;
+    int line_trace0, line_length;
     const int il = SEGY_TR_INLINE;
     const int xl = SEGY_TR_CROSSLINE;
 
@@ -68,10 +68,10 @@ static void test_interpret_file() {
     assertTrue( crosslines_sz == 5, "Expected 5 crosslines." );
 
     /* Inline-specific information */
-    unsigned int inline_indices[ 5 ];
+    int inline_indices[ 5 ];
     err = segy_inline_indices( fp, il, sorting, inlines_sz, crosslines_sz, offsets, inline_indices, trace0, trace_bsize );
     assertTrue( err == 0, "Could not determine inline linenos." );
-    for( unsigned int i = 0, ref = 1; i < 5; ++i, ++ref )
+    for( int i = 0, ref = 1; i < 5; ++i, ++ref )
         assertTrue( inline_indices[ i ] == ref,
                     "Inline lineno mismatch, should be [1..5]." );
 
@@ -87,10 +87,10 @@ static void test_interpret_file() {
     assertTrue( line_length == 5, "Inline length should be 5." );
 
     /* Crossline-specific information */
-    unsigned int crossline_indices[ 5 ];
+    int crossline_indices[ 5 ];
     err = segy_crossline_indices( fp, xl, sorting, inlines_sz, crosslines_sz, offsets, crossline_indices, trace0, trace_bsize );
     assertTrue( err == 0, "Could not determine crossline linenos." );
-    for( unsigned int i = 0, ref = 20; i < 5; ++i, ++ref )
+    for( int i = 0, ref = 20; i < 5; ++i, ++ref )
         assertTrue( crossline_indices[ i ] == ref,
                     "Crossline lineno mismatch, should be [20..24]." );
 
@@ -209,10 +209,9 @@ static void testReadInLine_4(){
 
     int sorting;
     int traces;
-    unsigned int inlines_sz, crosslines_sz;
-    int offsets, line_trace0;
-    unsigned int stride;
-    unsigned int line_length;
+    int inlines_sz, crosslines_sz;
+    int offsets, stride;
+    int line_trace0, line_length;
 
     /* test specific consts */
     const int il = SEGY_TR_INLINE, xl = SEGY_TR_CROSSLINE;
@@ -226,8 +225,8 @@ static void testReadInLine_4(){
     const int trace_bsize = segy_trace_bsize( samples );
     const int format = segy_format( header );
 
-    unsigned int inline_indices[ 5 ];
-    const unsigned int inline_length = 5;
+    int inline_indices[ 5 ];
+    const int inline_length = 5;
     float* data = malloc( inline_length * samples * sizeof( float ) );
 
     int ok = 0;
@@ -285,9 +284,9 @@ static void testReadCrossLine_22(){
 
     int sorting;
     int traces;
-    unsigned int inlines_sz, crosslines_sz;
-    unsigned int offsets, stride;
-    unsigned int line_trace0, line_length;
+    int inlines_sz, crosslines_sz;
+    int offsets, stride;
+    int line_length, line_trace0;
 
     /* test specific consts */
     const int il = SEGY_TR_INLINE, xl = SEGY_TR_CROSSLINE;
@@ -301,8 +300,8 @@ static void testReadCrossLine_22(){
     const int trace_bsize = segy_trace_bsize( samples );
     const int format = segy_format( header );
 
-    unsigned int crossline_indices[ 5 ];
-    const unsigned int crossline_length = 5;
+    int crossline_indices[ 5 ];
+    const int crossline_length = 5;
     float* data = malloc( crossline_length * samples * sizeof(float) );
 
     int ok = 0;
@@ -550,7 +549,7 @@ static void test_file_error_codes() {
     err = segy_writetrace( fp, 0, NULL, 3600, 350 );
     assertTrue( err == SEGY_FSEEK_ERROR, "Could seek in invalid file." );
 
-    unsigned int l1, l2;
+    int l1, l2;
     err = segy_count_lines( fp, 0, 1, &l1, &l2, 3600, 350 );
     assertTrue( err == SEGY_FSEEK_ERROR, "Could seek in invalid file." );
 }
@@ -558,12 +557,12 @@ static void test_file_error_codes() {
 static void test_error_codes_sans_file() {
     int err;
 
-    unsigned int linenos[] = { 0, 1, 2 };
+    int linenos[] = { 0, 1, 2 };
     err = segy_line_trace0( 10, 3, 1, 1, linenos, 3, NULL );
     assertTrue( err == SEGY_MISSING_LINE_INDEX,
                 "Found line number that shouldn't exist." );
 
-    unsigned int stride;
+    int stride;
     err = segy_inline_stride( SEGY_INLINE_SORTING + 3, 10, &stride );
     assertTrue( err == SEGY_INVALID_SORTING,
                 "Expected sorting to be invalid." );

--- a/lib/test/segy.c
+++ b/lib/test/segy.c
@@ -210,8 +210,9 @@ static void testReadInLine_4(){
     int sorting;
     int traces;
     unsigned int inlines_sz, crosslines_sz;
-    unsigned int offsets, stride;
-    unsigned int line_trace0, line_length;
+    int offsets, line_trace0;
+    unsigned int stride;
+    unsigned int line_length;
 
     /* test specific consts */
     const int il = SEGY_TR_INLINE, xl = SEGY_TR_CROSSLINE;

--- a/mex/segy_get_header_mex.c
+++ b/mex/segy_get_header_mex.c
@@ -27,7 +27,7 @@ void mexFunction(int nlhs, mxArray *plhs[],
 
     char header[ SEGY_TRACE_HEADER_SIZE ];
 
-    for( size_t i = 0; i < fmt.traces; ++i ) {
+    for( int i = 0; i < fmt.traces; ++i ) {
         int32_t f;
         err = segy_traceheader( fp, i, header, fmt.trace0, fmt.trace_bsize );
 

--- a/mex/segy_get_offsets_mex.c
+++ b/mex/segy_get_offsets_mex.c
@@ -43,7 +43,7 @@ void mexFunction(int nlhs, mxArray *plhs[],
     if( errc != SEGY_OK ) goto CLEANUP;
 
     int32_t* plhs0 = (int32_t*)mxGetData(plhs[0]);
-    for( unsigned int i = 0; i < spec.offset_count; ++i )
+    for( int i = 0; i < spec.offset_count; ++i )
         plhs0[i] = int_offsets[i];
 
     mxFree( int_offsets );

--- a/mex/segy_get_ps_line_mex.c
+++ b/mex/segy_get_ps_line_mex.c
@@ -43,7 +43,7 @@ void mexFunction(int nlhs, mxArray *plhs[],
     if( err != SEGY_OK ) goto CLEANUP;
 
     int32_t* plhs0 = (int32_t*)mxGetScalar(plhs[0]);
-    for( unsigned int i = 0; i < spec.sample_count; ++i )
+    for( int i = 0; i < spec.sample_count; ++i )
         plhs0[i] = int_offsets[i];
 
     segy_close(fp);

--- a/mex/segy_put_headers_mex.c
+++ b/mex/segy_put_headers_mex.c
@@ -34,7 +34,7 @@ void mexFunction(int nlhs, mxArray *plhs[],
     }
 
     double* itr = headers;
-    for( size_t i = 0; i < fmt.traces; ++i, ++itr ) {
+    for( int i = 0; i < fmt.traces; ++i, ++itr ) {
         err = segy_traceheader( fp, i, traceheader, fmt.trace0, fmt.trace_bsize );
         const int val = *itr;
 

--- a/mex/segy_put_traces_mex.c
+++ b/mex/segy_put_traces_mex.c
@@ -41,7 +41,7 @@ void mexFunction(int nlhs, mxArray *plhs[],
     }
 
     float* itr = out;
-    for( size_t i = first_trace; i < fmt.traces; ++i ) {
+    for( int i = first_trace; i < fmt.traces; ++i ) {
         err = segy_writetrace( fp, i, itr, fmt.trace0, fmt.trace_bsize );
         itr += fmt.samples;
 

--- a/mex/segy_read_write_line_mex.c
+++ b/mex/segy_read_write_line_mex.c
@@ -46,8 +46,7 @@ void mexFunction(int nlhs, mxArray *plhs[],
 
     segy_file* fp;
 
-    unsigned int line_trace0;
-
+    int line_trace0;
     int errc = segy_line_trace0( index, line_length, stride, offsets, line_indexes, line_count, &line_trace0 );
     if (errc != 0) {
         goto CLEANUP;

--- a/mex/segy_read_write_ps_line_mex.c
+++ b/mex/segy_read_write_ps_line_mex.c
@@ -36,7 +36,7 @@ void mexFunction(int nlhs, mxArray *plhs[],
 
     segy_file* fp;
 
-    unsigned int line_trace0;
+    int line_trace0;
     int errc = segy_line_trace0( index, line_length, stride, offsets, line_indexes, line_count, &line_trace0 );
     if( errc != SEGY_OK ) {
         mexErrMsgIdAndTxt( "segy:get_ps_line:wrong_line_number",

--- a/mex/segyspec_mex.c
+++ b/mex/segyspec_mex.c
@@ -122,7 +122,7 @@ void mexFunction( int nlhs, mxArray *plhs[],
     mxArray *mx_sample_indexes = mxCreateDoubleMatrix(spec.sample_count,1, mxREAL);
     double *mx_sample_indexes_ptr = mxGetPr(mx_sample_indexes);
     for (int i = 0; i < spec.sample_count; i++) {
-        mx_sample_indexes_ptr[i] = spec.sample_indexes[i];
+        mx_sample_indexes_ptr[i] = spec.sample_indices[i];
     }
     mxSetFieldByNumber(plhs[0], 0, 4, mx_sample_indexes);
 
@@ -137,8 +137,7 @@ void mexFunction( int nlhs, mxArray *plhs[],
         free(spec.crossline_indexes);
     if (spec.inline_indexes != NULL)
         free(spec.inline_indexes);
-    if (spec.sample_indexes != NULL)
-        free(spec.sample_indexes);
+    free(spec.sample_indices);
     if (spec.filename != NULL)
         free(spec.filename);
     mxFree(filename);

--- a/mex/segyutil.c
+++ b/mex/segyutil.c
@@ -46,7 +46,7 @@ int segyCreateSpec(SegySpec* spec, const char* file, unsigned int inline_field, 
     const long trace0 = segy_trace0( header );
 
     spec->trace_bsize = segy_trace_bsize( segy_samples( header ) );
-    size_t traces;
+    int traces;
     errc = segy_traces(fp, &traces, trace0, spec->trace_bsize);
     if (errc != 0) {
         goto CLEANUP;

--- a/mex/segyutil.c
+++ b/mex/segyutil.c
@@ -13,7 +13,7 @@ static char* copyString(const char* path) {
 }
 
 
-int segyCreateSpec(SegySpec* spec, const char* file, unsigned int inline_field, unsigned int crossline_field, double t0, double dt) {
+int segyCreateSpec(SegySpec* spec, const char* file, unsigned int inline_field, unsigned int crossline_field, float t0, float dt) {
 
     int errc = 0;
 
@@ -23,7 +23,7 @@ int segyCreateSpec(SegySpec* spec, const char* file, unsigned int inline_field, 
         return -1;
     }
 
-    spec->sample_indexes = NULL;
+    spec->sample_indices = NULL;
     spec->inline_indexes = NULL;
     spec->crossline_indexes = NULL;
 
@@ -37,8 +37,8 @@ int segyCreateSpec(SegySpec* spec, const char* file, unsigned int inline_field, 
     spec->sample_format = segy_format( header );
     spec->sample_count = segy_samples( header );
 
-    spec->sample_indexes = malloc(sizeof(double) * spec->sample_count);
-    errc = segy_sample_indexes(fp, spec->sample_indexes, t0, dt, spec->sample_count);
+    spec->sample_indices = malloc(sizeof(float) * spec->sample_count);
+    errc = segy_sample_indices(fp, t0, dt, spec->sample_count, spec->sample_indices );
     if (errc != 0) {
         goto CLEANUP;
     }
@@ -121,8 +121,7 @@ int segyCreateSpec(SegySpec* spec, const char* file, unsigned int inline_field, 
         free(spec->crossline_indexes);
     if (spec->inline_indexes != NULL)
         free(spec->inline_indexes);
-    if (spec->sample_indexes != NULL)
-        free(spec->sample_indexes);
+    free(spec->sample_indices);
     free(spec->filename);
 
     segy_close(fp);
@@ -161,7 +160,7 @@ void recreateSpec(SegySpec *spec, const mxArray* mex_spec) {
 
     mxArray* sample_indexes = mxGetProperty(mex_spec, 0, "sample_indexes");
     spec->sample_count = getMaxDim(sample_indexes);
-    spec->sample_indexes = mxGetData(sample_indexes);
+    spec->sample_indices = mxGetData(sample_indexes);
 
 }
 

--- a/mex/segyutil.c
+++ b/mex/segyutil.c
@@ -62,9 +62,9 @@ int segyCreateSpec(SegySpec* spec, const char* file, unsigned int inline_field, 
         goto CLEANUP;
     }
 
-    unsigned int* l1;
-    unsigned int* l2;
-    unsigned int field;
+    int* l1;
+    int* l2;
+    int field;
     if (spec->trace_sorting_format == SEGY_INLINE_SORTING) {
         field = crossline_field;
         l1 = &spec->inline_count;
@@ -83,8 +83,8 @@ int segyCreateSpec(SegySpec* spec, const char* file, unsigned int inline_field, 
         goto CLEANUP;
     }
 
-    spec->inline_indexes = malloc(sizeof(unsigned int) * spec->inline_count);
-    spec->crossline_indexes = malloc(sizeof(unsigned int) * spec->crossline_count);
+    spec->inline_indexes = malloc(sizeof(int) * spec->inline_count);
+    spec->crossline_indexes = malloc(sizeof(int) * spec->crossline_count);
 
     errc = segy_inline_indices(fp, inline_field, spec->trace_sorting_format,
                         spec->inline_count, spec->crossline_count, spec->offset_count, spec->inline_indexes,
@@ -143,13 +143,13 @@ static int getMaxDim(mxArray* arr){
 void recreateSpec(SegySpec *spec, const mxArray* mex_spec) {
 
     spec->filename = mxArrayToString(mxGetProperty(mex_spec, 0, "filename"));
-    spec->sample_format = (unsigned int)mxGetScalar(mxGetProperty(mex_spec, 0, "sample_format"));
-    spec->trace_sorting_format = (unsigned int)mxGetScalar(mxGetProperty(mex_spec, 0, "trace_sorting_format"));
-    spec->offset_count = (unsigned int)mxGetScalar(mxGetProperty(mex_spec, 0, "offset_count"));
-    spec->first_trace_pos = (unsigned int)mxGetScalar(mxGetProperty(mex_spec, 0, "first_trace_pos"));
-    spec->il_stride = (unsigned int)mxGetScalar(mxGetProperty(mex_spec, 0, "il_stride"));
-    spec->xl_stride = (unsigned int)mxGetScalar(mxGetProperty(mex_spec, 0, "xl_stride"));
-    spec->trace_bsize = (unsigned int)mxGetScalar(mxGetProperty(mex_spec, 0, "trace_bsize"));
+    spec->sample_format = (int)mxGetScalar(mxGetProperty(mex_spec, 0, "sample_format"));
+    spec->trace_sorting_format = (int)mxGetScalar(mxGetProperty(mex_spec, 0, "trace_sorting_format"));
+    spec->offset_count = (int)mxGetScalar(mxGetProperty(mex_spec, 0, "offset_count"));
+    spec->first_trace_pos = (int)mxGetScalar(mxGetProperty(mex_spec, 0, "first_trace_pos"));
+    spec->il_stride = (int)mxGetScalar(mxGetProperty(mex_spec, 0, "il_stride"));
+    spec->xl_stride = (int)mxGetScalar(mxGetProperty(mex_spec, 0, "xl_stride"));
+    spec->trace_bsize = (int)mxGetScalar(mxGetProperty(mex_spec, 0, "trace_bsize"));
 
     mxArray* crossline_indexes = mxGetProperty(mex_spec, 0, "crossline_indexes");
     spec->crossline_count = getMaxDim(crossline_indexes);

--- a/mex/segyutil.h
+++ b/mex/segyutil.h
@@ -22,7 +22,7 @@ typedef struct {
     unsigned int offset_count;
 
     double* sample_indexes;
-    unsigned int sample_count;
+    int sample_count;
 
     int trace_sorting_format;
 
@@ -38,7 +38,7 @@ int segyCreateSpec(SegySpec* spec, const char* file, unsigned int inline_field, 
 void recreateSpec(SegySpec* spec, const mxArray* mex_spec);
 
 struct segy_file_format {
-    unsigned int samples;
+    int samples;
     long trace0;
     unsigned int trace_bsize;
     size_t traces;

--- a/mex/segyutil.h
+++ b/mex/segyutil.h
@@ -21,7 +21,7 @@ typedef struct {
 
     int offset_count;
 
-    double* sample_indexes;
+    float* sample_indices;
     int sample_count;
 
     int trace_sorting_format;
@@ -33,7 +33,7 @@ typedef struct {
 
 } SegySpec;
 
-int segyCreateSpec(SegySpec* spec, const char* file, unsigned int inline_field, unsigned int crossline_field, double t0, double dt);
+int segyCreateSpec(SegySpec* spec, const char* file, unsigned int inline_field, unsigned int crossline_field, float t0, float dt);
 
 void recreateSpec(SegySpec* spec, const mxArray* mex_spec);
 

--- a/mex/segyutil.h
+++ b/mex/segyutil.h
@@ -41,7 +41,7 @@ struct segy_file_format {
     int samples;
     long trace0;
     unsigned int trace_bsize;
-    size_t traces;
+    int traces;
     int format;
 };
 

--- a/mex/segyutil.h
+++ b/mex/segyutil.h
@@ -11,25 +11,25 @@
 typedef struct {
     char* filename;
 
-    unsigned int sample_format;
+    int sample_format;
 
-    unsigned int* crossline_indexes;
-    unsigned int crossline_count;
+    int* crossline_indexes;
+    int crossline_count;
 
-    unsigned int* inline_indexes;
-    unsigned int inline_count;
+    int* inline_indexes;
+    int inline_count;
 
-    unsigned int offset_count;
+    int offset_count;
 
     double* sample_indexes;
     int sample_count;
 
     int trace_sorting_format;
 
-    unsigned int il_stride;
-    unsigned int xl_stride;
-    unsigned int first_trace_pos;
-    unsigned int trace_bsize;
+    int il_stride;
+    int xl_stride;
+    long first_trace_pos;
+    int trace_bsize;
 
 } SegySpec;
 
@@ -40,7 +40,7 @@ void recreateSpec(SegySpec* spec, const mxArray* mex_spec);
 struct segy_file_format {
     int samples;
     long trace0;
-    unsigned int trace_bsize;
+    int trace_bsize;
     int traces;
     int format;
 };

--- a/python/segyio/_segyio.c
+++ b/python/segyio/_segyio.c
@@ -442,9 +442,9 @@ static PyObject *py_read_trace_header(PyObject *self, PyObject *args) {
     unsigned int traceno;
     PyObject *trace_header_capsule = NULL;
     long trace0;
-    unsigned int trace_bsize;
+    int trace_bsize;
 
-    PyArg_ParseTuple(args, "OIOlI", &file_capsule, &traceno, &trace_header_capsule, &trace0, &trace_bsize);
+    PyArg_ParseTuple(args, "OIOli", &file_capsule, &traceno, &trace_header_capsule, &trace0, &trace_bsize);
 
     segy_file *p_FILE = get_FILE_pointer_from_capsule(file_capsule);
 
@@ -470,9 +470,9 @@ static PyObject *py_write_trace_header(PyObject *self, PyObject *args) {
     unsigned int traceno;
     PyObject *trace_header_capsule = NULL;
     long trace0;
-    unsigned int trace_bsize;
+    int trace_bsize;
 
-    PyArg_ParseTuple(args, "OIOlI", &file_capsule, &traceno, &trace_header_capsule, &trace0, &trace_bsize);
+    PyArg_ParseTuple(args, "OIOli", &file_capsule, &traceno, &trace_header_capsule, &trace0, &trace_bsize);
 
     segy_file *p_FILE = get_FILE_pointer_from_capsule(file_capsule);
 
@@ -497,9 +497,9 @@ static PyObject *py_trace_bsize(PyObject *self, PyObject *args) {
 
     PyArg_ParseTuple(args, "i", &sample_count);
 
-    unsigned int byte_count = segy_trace_bsize(sample_count);
+    int byte_count = segy_trace_bsize(sample_count);
 
-    return Py_BuildValue("I", byte_count);
+    return Py_BuildValue("i", byte_count);
 }
 
 static PyObject *py_get_dt(PyObject *self, PyObject *args) {
@@ -571,7 +571,7 @@ static PyObject *py_init_metrics(PyObject *self, PyObject *args) {
     long trace0 = segy_trace0(binary_header);
     int sample_count = segy_samples(binary_header);
     int format = segy_format(binary_header);
-    unsigned int trace_bsize = segy_trace_bsize(sample_count);
+    int trace_bsize = segy_trace_bsize(sample_count);
 
     int sorting;
     int error = segy_sorting(p_FILE, il_field, xl_field, &sorting, trace0, trace_bsize);
@@ -629,7 +629,7 @@ static PyObject *py_init_metrics(PyObject *self, PyObject *args) {
     PyDict_SetItemString(dict, "trace0", Py_BuildValue("l", trace0));
     PyDict_SetItemString(dict, "sample_count", Py_BuildValue("i", sample_count));
     PyDict_SetItemString(dict, "format", Py_BuildValue("i", format));
-    PyDict_SetItemString(dict, "trace_bsize", Py_BuildValue("I", trace_bsize));
+    PyDict_SetItemString(dict, "trace_bsize", Py_BuildValue("i", trace_bsize));
     PyDict_SetItemString(dict, "sorting", Py_BuildValue("i", sorting));
     PyDict_SetItemString(dict, "trace_count", Py_BuildValue("k", trace_count));
     PyDict_SetItemString(dict, "offset_count", Py_BuildValue("I", offset_count));
@@ -718,14 +718,14 @@ static PyObject *py_init_indices(PyObject *self, PyObject *args) {
     int offset_field;
     int sorting;
     long trace0;
-    unsigned int trace_bsize;
+    int trace_bsize;
 
     PyArg_Parse(PyDict_GetItemString(metrics, "iline_field"), "i", &il_field);
     PyArg_Parse(PyDict_GetItemString(metrics, "xline_field"), "i", &xl_field);
     PyArg_Parse(PyDict_GetItemString(metrics, "offset_field"), "i", &offset_field);
     PyArg_Parse(PyDict_GetItemString(metrics, "sorting"), "i", &sorting);
     PyArg_Parse(PyDict_GetItemString(metrics, "trace0"), "l", &trace0);
-    PyArg_Parse(PyDict_GetItemString(metrics, "trace_bsize"), "I", &trace_bsize);
+    PyArg_Parse(PyDict_GetItemString(metrics, "trace_bsize"), "i", &trace_bsize);
 
     int error = segy_inline_indices(p_FILE, il_field, sorting, iline_count, xline_count, offset_count, iline_buffer.buf,
                                     trace0, trace_bsize);
@@ -793,7 +793,7 @@ static PyObject *py_read_trace(PyObject *self, PyObject *args) {
     PyObject *buffer_out;
     int trace_count;
     long trace0;
-    unsigned int trace_bsize;
+    int trace_bsize;
     int format;
     unsigned int samples;
 
@@ -868,7 +868,7 @@ static PyObject *py_write_trace(PyObject *self, PyObject *args) {
     unsigned int trace_no;
     PyObject *buffer_in;
     long trace0;
-    unsigned int trace_bsize;
+    int trace_bsize;
     int format;
     unsigned int samples;
 
@@ -917,7 +917,7 @@ static PyObject *py_read_line(PyObject *self, PyObject *args) {
     int offsets;
     PyObject *buffer_in;
     long trace0;
-    unsigned int trace_bsize;
+    int trace_bsize;
     int format;
     unsigned int samples;
 
@@ -966,11 +966,11 @@ static PyObject *py_read_depth_slice(PyObject *self, PyObject *args) {
     int offsets;
     PyObject *buffer_out;
     long trace0;
-    unsigned int trace_bsize;
+    int trace_bsize;
     int format;
-    unsigned int samples;
+    int samples;
 
-    PyArg_ParseTuple(args, "OiiiOlIiI", &file_capsule,
+    PyArg_ParseTuple(args, "OiiiOliii", &file_capsule,
                                         &depth,
                                         &count,
                                         &offsets,

--- a/python/segyio/_segyio.c
+++ b/python/segyio/_segyio.c
@@ -522,12 +522,12 @@ static PyObject *py_get_dt(PyObject *self, PyObject *args) {
 static PyObject *py_init_line_metrics(PyObject *self, PyObject *args) {
     errno = 0;
     SEGY_SORTING sorting;
-    unsigned int trace_count;
+    int trace_count;
     unsigned int inline_count;
     unsigned int crossline_count;
     unsigned int offset_count;
 
-    PyArg_ParseTuple(args, "iIIII", &sorting, &trace_count, &inline_count, &crossline_count, &offset_count);
+    PyArg_ParseTuple(args, "iiIII", &sorting, &trace_count, &inline_count, &crossline_count, &offset_count);
 
     unsigned int iline_length = segy_inline_length(crossline_count);
 
@@ -580,7 +580,7 @@ static PyObject *py_init_metrics(PyObject *self, PyObject *args) {
         return py_handle_segy_error_with_fields(error, errno, il_field, xl_field, 2);
     }
 
-    size_t trace_count;
+    int trace_count;
     error = segy_traces(p_FILE, &trace_count, trace0, trace_bsize);
 
     if (error != 0) {
@@ -588,7 +588,7 @@ static PyObject *py_init_metrics(PyObject *self, PyObject *args) {
     }
 
     unsigned int offset_count;
-    error = segy_offsets(p_FILE, il_field, xl_field, (unsigned int) trace_count, &offset_count, trace0, trace_bsize);
+    error = segy_offsets(p_FILE, il_field, xl_field, trace_count, &offset_count, trace0, trace_bsize);
 
     if (error != 0) {
         return py_handle_segy_error_with_fields(error, errno, il_field, xl_field, 2);
@@ -631,7 +631,7 @@ static PyObject *py_init_metrics(PyObject *self, PyObject *args) {
     PyDict_SetItemString(dict, "format", Py_BuildValue("i", format));
     PyDict_SetItemString(dict, "trace_bsize", Py_BuildValue("i", trace_bsize));
     PyDict_SetItemString(dict, "sorting", Py_BuildValue("i", sorting));
-    PyDict_SetItemString(dict, "trace_count", Py_BuildValue("k", trace_count));
+    PyDict_SetItemString(dict, "trace_count", Py_BuildValue("i", trace_count));
     PyDict_SetItemString(dict, "offset_count", Py_BuildValue("I", offset_count));
     PyDict_SetItemString(dict, "iline_count", Py_BuildValue("I", il_count));
     PyDict_SetItemString(dict, "xline_count", Py_BuildValue("I", xl_count));

--- a/python/segyio/_segyio.c
+++ b/python/segyio/_segyio.c
@@ -261,7 +261,7 @@ static PyObject *py_read_texthdr(PyObject *self, PyObject *args) {
 static PyObject *py_write_texthdr(PyObject *self, PyObject *args) {
     errno = 0;
     PyObject *file_capsule = NULL;
-    unsigned int index;
+    int index;
     char *buffer;
     int size;
 

--- a/python/segyio/_segyio.c
+++ b/python/segyio/_segyio.c
@@ -439,12 +439,12 @@ static PyObject *py_empty_trace_header(PyObject *self) {
 static PyObject *py_read_trace_header(PyObject *self, PyObject *args) {
     errno = 0;
     PyObject *file_capsule = NULL;
-    unsigned int traceno;
+    int traceno;
     PyObject *trace_header_capsule = NULL;
     long trace0;
     int trace_bsize;
 
-    PyArg_ParseTuple(args, "OIOli", &file_capsule, &traceno, &trace_header_capsule, &trace0, &trace_bsize);
+    PyArg_ParseTuple(args, "OiOli", &file_capsule, &traceno, &trace_header_capsule, &trace0, &trace_bsize);
 
     segy_file *p_FILE = get_FILE_pointer_from_capsule(file_capsule);
 
@@ -467,12 +467,12 @@ static PyObject *py_read_trace_header(PyObject *self, PyObject *args) {
 static PyObject *py_write_trace_header(PyObject *self, PyObject *args) {
     errno = 0;
     PyObject *file_capsule = NULL;
-    unsigned int traceno;
+    int traceno;
     PyObject *trace_header_capsule = NULL;
     long trace0;
     int trace_bsize;
 
-    PyArg_ParseTuple(args, "OIOli", &file_capsule, &traceno, &trace_header_capsule, &trace0, &trace_bsize);
+    PyArg_ParseTuple(args, "OiOli", &file_capsule, &traceno, &trace_header_capsule, &trace0, &trace_bsize);
 
     segy_file *p_FILE = get_FILE_pointer_from_capsule(file_capsule);
 

--- a/python/segyio/_segyio.c
+++ b/python/segyio/_segyio.c
@@ -493,9 +493,9 @@ static PyObject *py_write_trace_header(PyObject *self, PyObject *args) {
 
 static PyObject *py_trace_bsize(PyObject *self, PyObject *args) {
     errno = 0;
-    unsigned int sample_count;
+    int sample_count;
 
-    PyArg_ParseTuple(args, "I", &sample_count);
+    PyArg_ParseTuple(args, "i", &sample_count);
 
     unsigned int byte_count = segy_trace_bsize(sample_count);
 
@@ -569,7 +569,7 @@ static PyObject *py_init_metrics(PyObject *self, PyObject *args) {
     if (PyErr_Occurred()) { return NULL; }
 
     long trace0 = segy_trace0(binary_header);
-    unsigned int sample_count = segy_samples(binary_header);
+    int sample_count = segy_samples(binary_header);
     int format = segy_format(binary_header);
     unsigned int trace_bsize = segy_trace_bsize(sample_count);
 
@@ -627,7 +627,7 @@ static PyObject *py_init_metrics(PyObject *self, PyObject *args) {
     PyDict_SetItemString(dict, "xline_field", Py_BuildValue("i", xl_field));
     PyDict_SetItemString(dict, "offset_field", Py_BuildValue("i", 37));
     PyDict_SetItemString(dict, "trace0", Py_BuildValue("l", trace0));
-    PyDict_SetItemString(dict, "sample_count", Py_BuildValue("I", sample_count));
+    PyDict_SetItemString(dict, "sample_count", Py_BuildValue("i", sample_count));
     PyDict_SetItemString(dict, "format", Py_BuildValue("i", format));
     PyDict_SetItemString(dict, "trace_bsize", Py_BuildValue("I", trace_bsize));
     PyDict_SetItemString(dict, "sorting", Py_BuildValue("i", sorting));

--- a/python/segyio/_segyio.c
+++ b/python/segyio/_segyio.c
@@ -506,8 +506,8 @@ static PyObject *py_get_dt(PyObject *self, PyObject *args) {
     errno = 0;
 
     PyObject *file_capsule = NULL;
-    double dt;
-    PyArg_ParseTuple(args, "Od", &file_capsule, &dt);
+    float dt;
+    PyArg_ParseTuple(args, "Of", &file_capsule, &dt);
     segy_file *p_FILE = get_FILE_pointer_from_capsule(file_capsule);
 
     if (PyErr_Occurred()) { return NULL; }
@@ -515,7 +515,8 @@ static PyObject *py_get_dt(PyObject *self, PyObject *args) {
     int error = segy_sample_interval(p_FILE, &dt);
     if (error != 0) { return py_handle_segy_error(error, errno); }
 
-    return PyFloat_FromDouble(dt);
+    double ddt = dt;
+    return PyFloat_FromDouble(ddt);
 }
 
 

--- a/python/segyio/create.py
+++ b/python/segyio/create.py
@@ -82,10 +82,10 @@ def create(filename, spec):
     f._tracecount    = len(spec.ilines) * len(spec.xlines) * len(spec.offsets)
 
     f._il            = int(spec.iline)
-    f._ilines        = numpy.copy(numpy.asarray(spec.ilines, dtype=numpy.uintc))
+    f._ilines        = numpy.copy(numpy.asarray(spec.ilines, dtype=numpy.intc))
 
     f._xl            = int(spec.xline)
-    f._xlines        = numpy.copy(numpy.asarray(spec.xlines, dtype=numpy.uintc))
+    f._xlines        = numpy.copy(numpy.asarray(spec.xlines, dtype=numpy.intc))
 
     line_metrics = _segyio.init_line_metrics(f.sorting, f.tracecount, len(f.ilines), len(f.xlines), len(f.offsets))
 

--- a/python/segyio/open.py
+++ b/python/segyio/open.py
@@ -67,9 +67,9 @@ def open(filename, mode="r", iline=189, xline=193):
         line_metrics = segyio._segyio.init_line_metrics(f.sorting, f.tracecount,
                                                         iline_count, xline_count, offset_count)
 
-        f._ilines  = numpy.zeros(iline_count, dtype=numpy.uintc)
-        f._xlines  = numpy.zeros(xline_count, dtype=numpy.uintc)
-        f._offsets = numpy.zeros(offset_count, dtype = numpy.uintc)
+        f._ilines  = numpy.zeros(iline_count, dtype=numpy.intc)
+        f._xlines  = numpy.zeros(xline_count, dtype=numpy.intc)
+        f._offsets = numpy.zeros(offset_count, dtype = numpy.intc)
         segyio._segyio.init_indices(f.xfd, metrics, f.ilines, f.xlines, f.offsets)
 
         f._iline_length = line_metrics['iline_length']

--- a/python/test/segyio_c.py
+++ b/python/test/segyio_c.py
@@ -196,7 +196,7 @@ class _segyioTests(TestCase):
         ilb = 189
         xlb = 193
         metrics = _segyio.init_metrics(f, binary_header, ilb, xlb)
-        dmy = numpy.zeros(2, dtype=numpy.uintc)
+        dmy = numpy.zeros(2, dtype=numpy.intc)
 
         dummy_metrics = {'xline_count':   2,
                          'iline_count':   2,
@@ -224,9 +224,9 @@ class _segyioTests(TestCase):
             fdmy = numpy.zeros(1, dtype=numpy.single)
             _segyio.init_indices(f, dummy_metrics, fdmy, dmy, dmy)
 
-        one = numpy.zeros(1, dtype=numpy.uintc)
-        two = numpy.zeros(2, dtype=numpy.uintc)
-        off = numpy.zeros(1, dtype=numpy.uintc)
+        one = numpy.zeros(1, dtype=numpy.intc)
+        two = numpy.zeros(2, dtype=numpy.intc)
+        off = numpy.zeros(1, dtype=numpy.intc)
         with self.assertRaises(ValueError):
             _segyio.init_indices(f, dummy_metrics, one, two, off)
 
@@ -234,8 +234,8 @@ class _segyioTests(TestCase):
             _segyio.init_indices(f, dummy_metrics, two, one, off)
 
         # Happy Path
-        iline_indexes = numpy.zeros(metrics['iline_count'], dtype=numpy.uintc)
-        xline_indexes = numpy.zeros(metrics['xline_count'], dtype=numpy.uintc)
+        iline_indexes = numpy.zeros(metrics['iline_count'], dtype=numpy.intc)
+        xline_indexes = numpy.zeros(metrics['xline_count'], dtype=numpy.intc)
         offsets       = numpy.zeros(metrics['offset_count'], dtype=numpy.intc)
         _segyio.init_indices(f, metrics, iline_indexes, xline_indexes, offsets)
 
@@ -262,8 +262,8 @@ class _segyioTests(TestCase):
 
         line_metrics = _segyio.init_line_metrics(sorting, trace_count, inline_count, crossline_count, offset_count)
 
-        iline_indexes = numpy.zeros(metrics['iline_count'], dtype=numpy.uintc)
-        xline_indexes = numpy.zeros(metrics['xline_count'], dtype=numpy.uintc)
+        iline_indexes = numpy.zeros(metrics['iline_count'], dtype=numpy.intc)
+        xline_indexes = numpy.zeros(metrics['xline_count'], dtype=numpy.intc)
         offsets       = numpy.zeros(metrics['offset_count'], dtype=numpy.intc)
         _segyio.init_indices(f, metrics, iline_indexes, xline_indexes, offsets)
 
@@ -396,8 +396,8 @@ class _segyioTests(TestCase):
 
         metrics.update(line_metrics)
 
-        iline_indexes = numpy.zeros(metrics['iline_count'], dtype=numpy.uintc)
-        xline_indexes = numpy.zeros(metrics['xline_count'], dtype=numpy.uintc)
+        iline_indexes = numpy.zeros(metrics['iline_count'], dtype=numpy.intc)
+        xline_indexes = numpy.zeros(metrics['xline_count'], dtype=numpy.intc)
         offsets       = numpy.zeros(metrics['offset_count'], dtype=numpy.intc)
         _segyio.init_indices(f, metrics, iline_indexes, xline_indexes, offsets)
 
@@ -451,7 +451,7 @@ class _segyioTests(TestCase):
 
     def test_fread_trace0_for_depth(self):
         elements = list(range(25))
-        indices = numpy.asarray(elements, dtype=numpy.uintc)
+        indices = numpy.asarray(elements, dtype=numpy.intc)
 
         for index in indices:
             d = _segyio.fread_trace0(index, 1, 1, 1, indices, "depth")

--- a/python/test/segyio_c.py
+++ b/python/test/segyio_c.py
@@ -236,7 +236,7 @@ class _segyioTests(TestCase):
         # Happy Path
         iline_indexes = numpy.zeros(metrics['iline_count'], dtype=numpy.uintc)
         xline_indexes = numpy.zeros(metrics['xline_count'], dtype=numpy.uintc)
-        offsets       = numpy.zeros(metrics['offset_count'], dtype=numpy.uintc)
+        offsets       = numpy.zeros(metrics['offset_count'], dtype=numpy.intc)
         _segyio.init_indices(f, metrics, iline_indexes, xline_indexes, offsets)
 
         self.assertListEqual([1, 2, 3, 4, 5], list(iline_indexes))
@@ -264,7 +264,7 @@ class _segyioTests(TestCase):
 
         iline_indexes = numpy.zeros(metrics['iline_count'], dtype=numpy.uintc)
         xline_indexes = numpy.zeros(metrics['xline_count'], dtype=numpy.uintc)
-        offsets       = numpy.zeros(metrics['offset_count'], dtype=numpy.uintc)
+        offsets       = numpy.zeros(metrics['offset_count'], dtype=numpy.intc)
         _segyio.init_indices(f, metrics, iline_indexes, xline_indexes, offsets)
 
         with self.assertRaises(KeyError):
@@ -398,7 +398,7 @@ class _segyioTests(TestCase):
 
         iline_indexes = numpy.zeros(metrics['iline_count'], dtype=numpy.uintc)
         xline_indexes = numpy.zeros(metrics['xline_count'], dtype=numpy.uintc)
-        offsets       = numpy.zeros(metrics['offset_count'], dtype=numpy.uintc)
+        offsets       = numpy.zeros(metrics['offset_count'], dtype=numpy.intc)
         _segyio.init_indices(f, metrics, iline_indexes, xline_indexes, offsets)
 
         return f, metrics, iline_indexes, xline_indexes


### PR DESCRIPTION
The mixture of signed and unsigned and various int types was largely an accident, and this PR attempts to clean up most of this. In short:

* All signatures have been reviewed and unless there's a good reason for some variable *not* to be int, it's int.
* The trace0 function still uses long, in order to be immediately associated with `fseek`. Overflow here isn't a problem since the trace0 is rather early in the file.
* Some explicit casts are added to silence conversion warnings that are deemed safe.
* `sample_indexes` have been renamed to `sample_indices` to be consistent with the rest of segyio, and has its argument shuffled around. Additionally, the arguments for this functions are now floats (as that's what we're working with in segyio) instead of doubles.