### PR TITLE
Ensure that files are always open in binary mode

### DIFF
--- a/lib/src/segy.c
+++ b/lib/src/segy.c
@@ -344,7 +344,23 @@ struct segy_file_handle {
 };
 
 segy_file* segy_open( const char* path, const char* mode ) {
-    FILE* fp = fopen( path, mode );
+
+    if( !path || !mode ) return NULL;
+
+    // append a 'b' if it is not passed by the user; not a problem on unix, but
+    // windows and other platforms fail without it
+    char binary_mode[ 4 ] = { 0 };
+    strncpy( binary_mode, mode, 3 );
+
+    size_t mode_len = strlen( binary_mode );
+    if( binary_mode[ mode_len - 1 ] != 'b' ) binary_mode[ mode_len ] = 'b';
+
+     // Account for invalid mode. On unix this is fine, but windows crashes the
+     // process if mode is invalid
+    if( !strstr( "rb" "wb" "ab" "r+b" "w+b" "a+b", binary_mode ) )
+        return NULL;
+
+    FILE* fp = fopen( path, binary_mode );
 
     if( !fp ) return NULL;
 
@@ -356,7 +372,7 @@ segy_file* segy_open( const char* path, const char* mode ) {
     }
 
     file->fp = fp;
-    strncpy( file->mode, mode, 3 );
+    strcpy( file->mode, binary_mode );
 
     return file;
 }

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -26,6 +26,10 @@ if (NOT PYTHONLIBS_FOUND)
     return()
 endif()
 
+if (NOT MSVC)
+    set(CMAKE_C_FLAGS "-std=c99 ${CMAKE_C_FLAGS}")
+endif()
+
 add_library(_segyio MODULE segyio/_segyio.c)
 target_include_directories(_segyio PRIVATE ${PYTHON_INCLUDE_DIRS})
 target_link_libraries(_segyio segyio ${PYTHON_LIBRARIES})

--- a/python/segyio/_segyio.c
+++ b/python/segyio/_segyio.c
@@ -72,23 +72,12 @@ static PyObject *py_FILE_open(PyObject *self, PyObject *args) {
         return NULL;
     }
 
-    // append a 'b' if it is not passed by the user; not a problem on unix, but
-    // windows and other platforms fail without it
-    // the heap alloc is expensive, but avoids the risk of local stack
-    // smashing and is C++ compatible
-    char* binary_mode = strcpy( calloc( mode_len + 2, sizeof( char ) ), mode );
-    if( binary_mode[ mode_len - 1 ] != 'b' ) binary_mode[ mode_len ] = 'b';
+    segy_file *p_FILE = segy_open( filename, mode );
 
-     // Account for invalid mode. On unix this is fine, but windows crashes the
-     // process if mode is invalid
-    if( !strstr( "rb" "wb" "ab" "r+b" "w+b" "a+b", binary_mode ) ) {
-        PyErr_Format( PyExc_IOError, "Invalid mode string '%s'", binary_mode );
-        free( binary_mode );
+    if( !p_FILE && !strstr( "rb" "wb" "ab" "r+b" "w+b" "a+b", mode ) ) {
+        PyErr_Format( PyExc_IOError, "Invalid mode string '%s'", mode );
         return NULL;
     }
-
-    segy_file *p_FILE = segy_open( filename, binary_mode );
-    free( binary_mode );
 
     if (p_FILE == NULL) {
         return PyErr_SetFromErrnoWithFilename(PyExc_IOError, filename);


### PR DESCRIPTION
Previously this was enforced by the python C bindings, but this is
common functionality to ensure correctness on multiple platforms, so it
makes sense to have it in the shared C core.