### PR TITLE
Fast/slow dimension alias

### DIFF
--- a/python/segyio/segy.py
+++ b/python/segyio/segy.py
@@ -687,6 +687,39 @@ class SegyFile(object):
         return self._shape_buffer(shape, buf)
 
     @property
+    def fast(self):
+        """ Access the 'fast' dimension
+
+        This mode yields iline or xline mode, depending on which one is laid
+        out "faster", i.e. the line with linear disk layout. Use this mode if
+        the inline/crossline distinction isn't as interesting as traversing in
+        a fast manner (typically when you want to apply a function to the whole
+        file, line-by-line).
+        """
+        if self.sorting == TraceSortingFormat.INLINE_SORTING:
+            return self.iline
+        elif self.sorting == TraceSortingFormat.CROSSLINE_SORTING:
+            return self.xline
+        else:
+            raise RuntimeError("Unknown sorting.")
+
+    @property
+    def slow(self):
+        """ Access the 'slow' dimension
+
+        This mode yields iline or xline mode, depending on which one is laid
+        out "slower", i.e. the line with strided disk layout. Use this mode if
+        the inline/crossline distinction isn't as interesting as traversing in
+        the slower direction.
+        """
+        if self.sorting == TraceSortingFormat.INLINE_SORTING:
+            return self.xline
+        elif self.sorting == TraceSortingFormat.CROSSLINE_SORTING:
+            return self.iline
+        else:
+            raise RuntimeError("Unknown sorting.")
+
+    @property
     def depth_slice(self):
         """ Interact with segy in depth slice mode.
 

--- a/python/test/segy.py
+++ b/python/test/segy.py
@@ -320,10 +320,10 @@ class TestSegy(TestCase):
 
     def test_fast_slow_dimensions(self):
         with segyio.open(self.filename, 'r') as f:
-            for iline, fline in itertools.izip(f.iline, f.fast):
+            for iline, fline in zip(f.iline, f.fast):
                 self.assertTrue(np.array_equal(iline, fline))
 
-            for xline, sline in itertools.izip(f.xline, f.slow):
+            for xline, sline in zip(f.xline, f.slow):
                 self.assertTrue(np.array_equal(iline, fline))
 
     def test_traces_raw(self):

--- a/python/test/segy.py
+++ b/python/test/segy.py
@@ -318,6 +318,14 @@ class TestSegy(TestCase):
             for line in f.xline:
                 pass
 
+    def test_fast_slow_dimensions(self):
+        with segyio.open(self.filename, 'r') as f:
+            for iline, fline in itertools.izip(f.iline, f.fast):
+                self.assertTrue(np.array_equal(iline, fline))
+
+            for xline, sline in itertools.izip(f.xline, f.slow):
+                self.assertTrue(np.array_equal(iline, fline))
+
     def test_traces_raw(self):
         with segyio.open(self.filename, "r") as f:
             gen_traces = np.array(list(map( np.copy, f.trace )), dtype = np.single)


### PR DESCRIPTION
Some programs aren't as interested in the inline/crossline distinction,
but rather which line-by-line traversal that gives the fastest program.
For these cases the fast/slow mode aliases checks sorting and figures
out which line type is the correct, and returns that.