### PR TITLE
Correct first/last index in mex/put_traces

### DIFF
--- a/mex/segy_put_traces_mex.c
+++ b/mex/segy_put_traces_mex.c
@@ -20,28 +20,26 @@ void mexFunction(int nlhs, mxArray *plhs[],
     int last_trace  = mxGetScalar( prhs[ 3 ] );
     int notype      = mxGetScalar( prhs[ 4 ] );
 
-    char binary[ SEGY_BINARY_HEADER_SIZE ];
     struct segy_file_format fmt = filefmt( fp );
 
     if( notype != -1 )
         fmt.format = notype;
 
-    if( last_trace != 1 && last_trace < fmt.traces )
-        fmt.traces = (last_trace + 1);
+    // if last_trace was defaulted we assign it to the last trace in the file
+    if( last_trace == -1 )
+        last_trace = fmt.traces - 1;
 
-    fmt.traces -= first_trace;
-
-    float* out      = mxGetData( plhs[ 0 ] );
-    segy_from_native( fmt.format, fmt.samples * fmt.traces, out );
-
-    if( first_trace > fmt.traces ) {
+    if( first_trace > last_trace ) {
         msg1 = "segy:get_traces:bounds";
         msg2 = "first trace must be smaller than last trace";
         goto cleanup;
     }
 
+    float* out      = mxGetData( plhs[ 0 ] );
+    segy_from_native( fmt.format, fmt.samples * fmt.traces, out );
+
     float* itr = out;
-    for( int i = first_trace; i < fmt.traces; ++i ) {
+    for( int i = first_trace; i <= last_trace; ++i ) {
         err = segy_writetrace( fp, i, itr, fmt.trace0, fmt.trace_bsize );
         itr += fmt.samples;
 
@@ -63,7 +61,6 @@ void mexFunction(int nlhs, mxArray *plhs[],
 
 cleanup:
     segy_close( fp );
-    segy_to_native( fmt.format, fmt.samples * fmt.traces, out );
 
     mexErrMsgIdAndTxt( msg1, msg2 );
 }


### PR DESCRIPTION
The old computation was straight-up wrong - now uses the same algorithm
as get_traces.