### PR TITLE
Avoid overflow on large chunks in segy_to_native

### DIFF
--- a/lib/include/segyio/segy.h
+++ b/lib/include/segyio/segy.h
@@ -170,13 +170,17 @@ int segy_writesubtr( segy_file*,
                      long trace0,
                      int trace_bsize );
 
-/* convert to/from native float from segy formats (likely IBM or IEEE) */
+/*
+ * convert to/from native float from segy formats (likely IBM or IEEE).  Size
+ * parameter is long long because it needs to know the number of *samples*,
+ * which can be very large for bulk conversion of a collection of traces.
+ */
 int segy_to_native( int format,
-                    int size,
+                    long long size,
                     float* buf );
 
 int segy_from_native( int format,
-                      int size,
+                      long long size,
                       float* buf );
 
 int segy_read_line( segy_file* fp,

--- a/lib/src/segy.c
+++ b/lib/src/segy.c
@@ -1172,7 +1172,7 @@ int segy_writesubtr( segy_file* fp,
 }
 
 int segy_to_native( int format,
-                    int size,
+                    long long size,
                     float* buf ) {
 
     assert( sizeof( float ) == sizeof( uint32_t ) );
@@ -1196,7 +1196,7 @@ int segy_to_native( int format,
 }
 
 int segy_from_native( int format,
-                      int size,
+                      long long size,
                       float* buf ) {
 
     assert( sizeof( float ) == sizeof( uint32_t ) );

--- a/mex/segy_get_traces_mex.c
+++ b/mex/segy_get_traces_mex.c
@@ -34,6 +34,7 @@ void mexFunction(int nlhs, mxArray *plhs[],
         last_trace = fmt.traces - 1;
 
     int traces = 1 + (last_trace - first_trace);
+    long long bufsize = (long long)fmt.samples * traces;
 
     plhs[0] = mxCreateNumericMatrix( fmt.samples, traces, mxSINGLE_CLASS, mxREAL );
     float* out = mxGetData( plhs[ 0 ] );
@@ -60,7 +61,7 @@ void mexFunction(int nlhs, mxArray *plhs[],
     if( notype != -1 )
         fmt.format = notype;
 
-    segy_to_native( fmt.format, fmt.samples * traces, mxGetData( plhs[ 0 ] ) );
+    segy_to_native( fmt.format, bufsize, mxGetData( plhs[ 0 ] ) );
 
     int interval;
     segy_get_bfield( binary, SEGY_BIN_INTERVAL, &interval );

--- a/mex/segy_put_traces_mex.c
+++ b/mex/segy_put_traces_mex.c
@@ -29,6 +29,9 @@ void mexFunction(int nlhs, mxArray *plhs[],
     if( last_trace == -1 )
         last_trace = fmt.traces - 1;
 
+    int traces = 1 + (last_trace - first_trace);
+    long long bufsize = (long long)fmt.samples * traces;
+
     if( first_trace > last_trace ) {
         msg1 = "segy:get_traces:bounds";
         msg2 = "first trace must be smaller than last trace";
@@ -52,15 +55,14 @@ void mexFunction(int nlhs, mxArray *plhs[],
     }
 
     segy_close( fp );
-
-    segy_to_native( fmt.format, fmt.samples * fmt.traces, out );
-
+    segy_to_native( fmt.format, bufsize, out );
     plhs[ 1 ] = mxCreateDoubleScalar( fmt.format );
 
     return;
 
 cleanup:
     segy_close( fp );
+    segy_to_native( fmt.format, bufsize, out );
 
     mexErrMsgIdAndTxt( msg1, msg2 );
 }

--- a/python/segyio/_segyio.c
+++ b/python/segyio/_segyio.c
@@ -835,13 +835,13 @@ static PyObject *py_read_trace(PyObject *self, PyObject *args) {
         error = segy_readtrace(p_FILE, start + (i * step), buf, trace0, trace_bsize);
     }
 
-    int conv_error = segy_to_native(format, length * samples, buffer.buf);
+    long long bufsize = (long long) length * samples;
+    int conv_error = segy_to_native(format, bufsize, buffer.buf);
     PyBuffer_Release( &buffer );
 
     if (error != 0) {
         return py_handle_segy_error_with_index_and_name(error, errno, start + (i * step), "Trace");
     }
-
 
     if (conv_error != 0) {
         PyErr_SetString(PyExc_TypeError, "Unable to convert buffer to native format.");


### PR DESCRIPTION
When large amounts of traces are collected in one go, it usually means a
high number of samples too. This risks integer overflow, typically
happening for files >8G, which are common. segy_to/from_native taking
long long for size fixes this issue.