### PR TITLE
tools.native - convert from segy to native float

### DIFF
--- a/python/segyio/__init__.py
+++ b/python/segyio/__init__.py
@@ -86,7 +86,7 @@ from .binfield import BinField
 from .open import open
 from .create import create
 from .segy import SegyFile, spec
-from .tools import dt, sample_indexes, create_text_header
+from .tools import dt, sample_indexes, create_text_header, native
 
 __version__    = '1.0.4'
 __copyright__  = 'Copyright 2016, Statoil ASA'

--- a/python/segyio/_segyio.c
+++ b/python/segyio/_segyio.c
@@ -1009,6 +1009,30 @@ static PyObject *py_read_depth_slice(PyObject *self, PyObject *args) {
     return buffer_out;
 }
 
+static PyObject * py_format(PyObject *self, PyObject *args) {
+    PyObject *out;
+    int format;
+
+    PyArg_ParseTuple( args, "Oi", &out, &format );
+
+    Py_buffer buffer;
+    PyObject_GetBuffer( out, &buffer,
+                        PyBUF_FORMAT | PyBUF_C_CONTIGUOUS | PyBUF_WRITEABLE );
+
+    int err = segy_to_native( format, buffer.len / buffer.itemsize, buffer.buf );
+
+    PyBuffer_Release( &buffer );
+
+    if( err != SEGY_OK ) {
+        PyErr_SetString( PyExc_RuntimeError, "Unable to convert to native float." );
+        return NULL;
+    }
+
+    Py_IncRef( out );
+    return out;
+}
+
+
 /*  define functions in module */
 static PyMethodDef SegyMethods[] = {
         {"open",               (PyCFunction) py_FILE_open,          METH_VARARGS, "Opens a file."},
@@ -1043,9 +1067,9 @@ static PyMethodDef SegyMethods[] = {
         {"read_line",          (PyCFunction) py_read_line,          METH_VARARGS, "Read a xline/iline from file."},
         {"depth_slice",        (PyCFunction) py_read_depth_slice,   METH_VARARGS, "Read a depth slice."},
         {"get_dt",             (PyCFunction) py_get_dt,             METH_VARARGS, "Read dt from file."},
+        {"native",             (PyCFunction) py_format,             METH_VARARGS, "Convert to native float."},
         {NULL, NULL, 0, NULL}
 };
-
 
 /* module initialization */
 #ifdef IS_PY3K

--- a/python/segyio/tools.py
+++ b/python/segyio/tools.py
@@ -50,3 +50,29 @@ def create_text_header(lines):
 
     rows = ''.join(rows)
     return rows
+
+def native(data,
+           format = segyio.SegySampleFormat.IBM_FLOAT_4_BYTE,
+           copy = True):
+    """ Convert numpy array to native float
+
+    :type data: numpy.ndarray
+    :type format: int|segyio.SegySampleFormat
+    :type copy: bool
+    :rtype: numpy.ndarray
+
+    Converts a numpy array from raw segy trace data to native floats. Works for numpy ndarrays.
+
+    Examples:
+        Convert mmap'd trace to native float:
+        >>> d = np.memmap('file.sgy', offset = 3600, dtype = np.uintc)
+        >>> samples = 1500
+        >>> trace = segyio.tools.native(d[240:240+samples])
+    """
+
+    data = data.view( dtype = np.single )
+    if copy:
+        data = np.copy( data )
+
+    format = int(segyio.SegySampleFormat(format))
+    return segyio._segyio.native(data, format)

--- a/python/test/tools.py
+++ b/python/test/tools.py
@@ -64,3 +64,13 @@ class ToolsTest(TestCase):
         for line_no in range(0, 40):
             line = text_header[line_no * 80: (line_no + 1) * 80]
             self.assertEqual(line, "C{0:>2} {1:76}".format(line_no + 1, chr(64 + line_no) * 76))
+
+    def test_native(self):
+        with open(self.filename, 'rb') as f, segyio.open(self.filename) as sgy:
+            f.read(3600+240)
+            filetr = f.read(4 * sgy.samples)
+            segytr = sgy.trace[0]
+
+            filetr = np.frombuffer(filetr, dtype = np.single)
+            self.assertFalse(np.array_equal(segytr, filetr))
+            self.assertTrue(np.array_equal(segytr, segyio.tools.native(filetr)))


### PR DESCRIPTION
Exposes segy-to-native float conversion so that it can be used from
python.