### PR TITLE
Read field forall

### DIFF
--- a/lib/include/segyio/segy.h
+++ b/lib/include/segyio/segy.h
@@ -61,6 +61,15 @@ int segy_get_bfield( const char* binheader, int field, int32_t* f );
 int segy_set_field( char* traceheader, int field, int32_t val );
 int segy_set_bfield( char* binheader, int field, int32_t val );
 
+int segy_field_forall( segy_file*,
+                       int field,
+                       int start,
+                       int stop,
+                       int step,
+                       int* buf,
+                       long trace0,
+                       int trace_bsize );
+
 /*
  * exception: segy_trace_bsize computes the size of the traces in bytes. Cannot
  * fail.

--- a/lib/src/segy.def
+++ b/lib/src/segy.def
@@ -14,6 +14,7 @@ segy_get_field
 segy_get_bfield
 segy_set_field
 segy_set_bfield
+segy_field_forall
 segy_trace_bsize
 segy_trace0
 segy_traces

--- a/mex/Segy.m
+++ b/mex/Segy.m
@@ -49,7 +49,7 @@ classdef Segy
         end
 
         % Goal:
-        %   Fast reading of trace header words in segy filenamele.
+        %   Fast reading of trace header words in segy file.
         %
         % Algorithm:
         %   Use keyword as specified in available_headers. If byte location is

--- a/mex/segy_get_header_mex.c
+++ b/mex/segy_get_header_mex.c
@@ -11,51 +11,36 @@
 void mexFunction(int nlhs, mxArray *plhs[],
                  int nrhs, const mxArray *prhs[]) {
 
-    char* msg1;
-    char* msg2;
+    char* msg1 = "";
+    char* msg2 = "";
     int err;
 
     const char* filename = mxArrayToString( prhs[ 0 ] );
     segy_file* fp = segyfopen( prhs[ 0 ], "rb" );
+
+    if( !fp ) goto cleanup;
 
     int field = mxGetScalar( prhs[ 1 ] );
 
     struct segy_file_format fmt = filefmt( fp );
 
     plhs[0] = mxCreateNumericMatrix( 1, fmt.traces, mxINT32_CLASS, mxREAL );
-    int32_t* out = mxGetData( plhs[ 0 ] );
+    int* out = mxGetData( plhs[ 0 ] );
 
-    char header[ SEGY_TRACE_HEADER_SIZE ];
 
-    for( int i = 0; i < fmt.traces; ++i ) {
-        int32_t f;
-        err = segy_traceheader( fp, i, header, fmt.trace0, fmt.trace_bsize );
+    err = segy_field_forall( fp, field,
+                             0, fmt.traces, 1, /* start, stop, step */
+                             out, fmt.trace0, fmt.trace_bsize );
 
-        if( err != 0 ) {
-            msg1 = "segy:get_header:segy_traceheader";
-            msg2 = strerror( errno );
-            goto cleanup;
-        }
-
-        err = segy_get_field( header, field, &f );
-
-        if( err != 0 ) {
-            msg1 = "segy:get_header:segy_get_field";
-            msg2 = "Error reading header field.";
-            goto cleanup;
-        }
-
-        out[ i ] = f;
-    }
-
+    int no = errno;
     segy_close( fp );
+
+    if( err != SEGY_OK )
+        mexErrMsgIdAndTxt( "segy:get_header:forall", strerror( errno ) );
 
     plhs[ 1 ] = mxCreateDoubleScalar( fmt.traces );
     return;
 
 cleanup:
-    segy_close( fp );
-
-cleanup_fopen:
-    mexErrMsgIdAndTxt( msg1, msg2 );
+    mexErrMsgIdAndTxt( "segy:get_header:fopen", strerror( errno ) );
 }

--- a/python/test/segy.py
+++ b/python/test/segy.py
@@ -232,6 +232,47 @@ class TestSegy(TestCase):
                 self.assertEqual(f.header[1][xl], 13)
                 self.assertEqual(f.header[2][xl], 2)
 
+    def test_attributes(self):
+        with segyio.open(self.filename) as f:
+            il = TraceField.INLINE_3D
+            xl = TraceField.CROSSLINE_3D
+
+            self.assertEqual(1,  f.attributes(il)[0])
+            self.assertEqual(20, f.attributes(xl)[0])
+
+            ils = [(i // 5) + 1 for i in range(25)]
+            attrils = list(map(int, f.attributes(il)[:]))
+            self.assertListEqual(ils, attrils)
+
+            xls = [(i % 5) + 20 for i in range(25)]
+            attrxls = list(map(int, f.attributes(xl)[:]))
+            self.assertListEqual(xls, attrxls)
+
+            ils = [(i // 5) + 1 for i in range(25)][::-1]
+            attrils = list(map(int, f.attributes(il)[::-1]))
+            self.assertListEqual(ils, attrils)
+
+            xls = [(i % 5) + 20 for i in range(25)][::-1]
+            attrxls = list(map(int, f.attributes(xl)[::-1]))
+            self.assertListEqual(xls, attrxls)
+
+            ils = [(i // 5) + 1 for i in range(25)][1:21:3]
+            attrils = list(map(int, f.attributes(il)[1:21:3]))
+            self.assertListEqual(ils, attrils)
+
+            xls = [(i % 5) + 20 for i in range(25)][2:17:5]
+            attrxls = list(map(int, f.attributes(xl)[2:17:5]))
+            self.assertListEqual(xls, attrxls)
+
+            ils = [1, 2, 3, 4, 5]
+            attrils = list(map(int, f.attributes(il)[[0, 5, 11, 17, 23]]))
+            self.assertListEqual(ils, attrils)
+
+            ils = [1, 2, 3, 4, 5]
+            indices = np.asarray([0, 5, 11, 17, 23])
+            attrils = list(map(int, f.attributes(il)[indices]))
+            self.assertListEqual(ils, attrils)
+
     def test_iline_offset(self):
         with segyio.open(self.prestack, "r") as f:
 


### PR DESCRIPTION
A common use case is to inspect some property of a file by scanning
through all or a subset of headers and look at one field in particular.
Doing this operation in a scripting language over medium and large files
is very computationally expensive, but it's rather cheap if you drop
down in C.

The new function segy.attribute leverages the segy_field_forall function
to support reading some field across the full file or parts of the file.
Uses cases include learning things about a new file, make assumptions on
structure and plot ensembles, CDP etc.

The interface is designed to quickly give control to numpy or other
third-party libs, and the return value is always an array or a simple
value. Supports looking up attributes for a single trace, a range (via
slice operations [start:stop:step]) or lists of indices.

Example usage: `f.attributes(CDP)[100:200]` for the CDP word of traces 100 through 199.

Matlab's get_header has been re-implemented using this new function for speed.