### PR TITLE
Don't check seek errors in mmap-case loop

### DIFF
--- a/lib/src/segy.c
+++ b/lib/src/segy.c
@@ -557,12 +557,18 @@ int segy_field_forall( segy_file* fp,
 
     int slicelen = slicelength( start, stop, step );
 
+    // check *once* that we don't look past the end-of-file
+    // checking seek error inside the loop is a performance killer
+    err = segy_seek( fp, start, trace0, trace_bsize );
+    if( err != SEGY_OK ) return err;
+    const int end = start + step * (slicelen - 1);
+    err = segy_seek( fp, end, trace0, trace_bsize );
+    if( err != SEGY_OK ) return err;
+
     if( fp->addr ) {
         for( int i = start; slicelen > 0; i += step, ++buf, --slicelen ) {
-            err = segy_seek( fp, i, trace0, trace_bsize );
-            if( err != 0 ) return SEGY_FSEEK_ERROR;
-
-            segy_get_field( fp->cur, field, &f );
+            segy_seek( fp, i, trace0, trace_bsize );
+            get_field( fp->cur, field_size, field, &f );
             *buf = f;
         }
 

--- a/python/segyio/segy.py
+++ b/python/segyio/segy.py
@@ -30,6 +30,9 @@ try:
 except ImportError:  # will be 3.x series
     pass
 
+try: xrange
+except NameError: pass
+else: range = xrange
 
 class SegyFile(object):
 


### PR DESCRIPTION
segy_seek when the file is mmap'd is a pointer bump, and it's only
necessary to check for seek errors for the first/last trace. If both
these are fine then all traces between them are obviously fine, and we
don't need to check the error 

xrange is aliased to range for python2.