### PR TITLE
Unstructured open

### DIFF
--- a/python/segyio/segy.py
+++ b/python/segyio/segy.py
@@ -33,6 +33,8 @@ except ImportError:  # will be 3.x series
 
 class SegyFile(object):
 
+    _unstructured_errmsg = "File opened in unstructured mode."
+
     def __init__(self, filename, mode, iline=189, xline=193):
         """
         Constructor, internal.
@@ -67,16 +69,23 @@ class SegyFile(object):
 
     def __str__(self):
         f = "SegyFile {}:".format(self._filename)
-        il =  "  inlines: {} [{}, {}]".format(len(self.ilines), self.ilines[0], self.ilines[-1])
-        xl =  "  crosslines: {} [{}, {}]".format(len(self.xlines), self.xlines[0], self.xlines[-1])
+
+        if self.unstructured:
+            il =  "  inlines: None"
+            xl =  "  crosslines: None"
+            of =  "  offsets: None"
+        else:
+            il =  "  inlines: {} [{}, {}]".format(len(self.ilines), self.ilines[0], self.ilines[-1])
+            xl =  "  crosslines: {} [{}, {}]".format(len(self.xlines), self.xlines[0], self.xlines[-1])
+            of =  "  offsets: {} [{}, {}]".format(len(self.offsets), self.offsets[0], self.offsets[-1])
+
         tr =  "  traces: {}".format(self.tracecount)
         sm =  "  samples: {}".format(self.samples)
-        of =  "  offsets: {} [{}, {}]".format(len(self.offsets), self.offsets[0], self.offsets[-1])
         fmt = "  float representation: {}".format(self.format)
 
         props = [f, il, xl, tr, sm]
 
-        if len(self.offsets) > 1:
+        if self.offsets is not None and len(self.offsets) > 1:
             props.append(of)
 
         props.append(fmt)
@@ -178,6 +187,9 @@ class SegyFile(object):
         """ :rtype: int """
         return self._ext_headers
 
+    @property
+    def unstructured(self):
+        return self.ilines is None
 
     @property
     def header(self):
@@ -579,6 +591,10 @@ class SegyFile(object):
             Copy an iline from f to g at g's offset 200::
                 >>> g.iline[12, 200] = f.iline[21]
         """
+
+        if self.unstructured:
+            raise ValueError(self._unstructured_errmsg)
+
         il_len, il_stride = self._iline_length, self._iline_stride
         lines = self.ilines
         other_lines = self.xlines
@@ -708,6 +724,10 @@ class SegyFile(object):
             Copy an xline from f to g at g's offset 200::
                 >>> g.xline[12, 200] = f.xline[21]
         """
+
+        if self.unstructured:
+            raise ValueError(self._unstructured_errmsg)
+
         xl_len, xl_stride = self._xline_length, self._xline_stride
         lines = self.xlines
         other_lines = self.ilines
@@ -829,6 +849,10 @@ class SegyFile(object):
             Copy every other depth slices from a different file::
                 >>> f.depth_slice = g.depth_slice[::2]
         """
+
+        if self.unstructured:
+            raise ValueError(self._unstructured_errmsg)
+
         indices = np.asarray(list(range(self.samples)), dtype=np.uintc)
         other_indices = np.asarray([0], dtype=np.uintc)
         buffn = self._depth_buffer

--- a/python/test/segy.py
+++ b/python/test/segy.py
@@ -559,7 +559,7 @@ class TestSegy(TestCase):
             # operations that don't rely on geometry still works
             self.assertEqual(f.header[2][189], 1)
             self.assertListEqual(list(f.attributes(189)[:]),
-                                 [(i / 5) + 1 for i in range(len(f.trace))])
+                                 [(i // 5) + 1 for i in range(len(f.trace))])
 
     def test_create_sgy(self):
         with TestContext("create_sgy") as context:

--- a/python/test/segy.py
+++ b/python/test/segy.py
@@ -171,6 +171,10 @@ class TestSegy(TestCase):
             self.assertEqual(len(f.trace), f.tracecount)
             self.assertEqual(50, f.samples)
 
+    def test_open_nostrict(self):
+        with segyio.open(self.filename, strict = False):
+            pass
+
     def test_traces_slicing(self):
         with segyio.open(self.filename, "r") as f:
 
@@ -223,7 +227,7 @@ class TestSegy(TestCase):
                 f.header.iline[1,2] = { il: 11 }
                 f.header.iline[1,2] = { xl: 13 }
 
-            with segyio.open("small-ps.sgy", "r") as f:
+            with segyio.open("small-ps.sgy", "r", strict = False) as f:
                 self.assertEqual(f.header[0][il], 1)
                 self.assertEqual(f.header[1][il], 11)
                 self.assertEqual(f.header[2][il], 1)
@@ -517,10 +521,16 @@ class TestSegy(TestCase):
             with segyio.open(self.filename, "r", 2) as f:
                 pass
 
+        with segyio.open(self.filename, "r", 2, strict = False) as f:
+            pass
+
     def test_open_wrong_crossline(self):
         with self.assertRaises(IndexError):
             with segyio.open(self.filename, "r", 189, 2) as f:
                 pass
+
+        with segyio.open(self.filename, "r", 189, 2, strict = False) as f:
+            pass
 
     def test_wonky_dimensions(self):
         with segyio.open(self.fileMx1) as f:
@@ -531,6 +541,25 @@ class TestSegy(TestCase):
 
         with segyio.open(self.file1x1) as f:
             pass
+
+    def test_open_fails_unstructured(self):
+        with segyio.open(self.filename, "r", 37, strict = False) as f:
+            with self.assertRaises(ValueError):
+                f.iline[10]
+
+            with self.assertRaises(ValueError):
+                f.iline[:,:]
+
+            with self.assertRaises(ValueError):
+                f.xline[:,:]
+
+            with self.assertRaises(ValueError):
+                f.depth_slice[2]
+
+            # operations that don't rely on geometry still works
+            self.assertEqual(f.header[2][189], 1)
+            self.assertListEqual(list(f.attributes(189)[:]),
+                                 [(i / 5) + 1 for i in range(len(f.trace))])
 
     def test_create_sgy(self):
         with TestContext("create_sgy") as context:

--- a/python/test/segyio_c.py
+++ b/python/test/segyio_c.py
@@ -124,7 +124,11 @@ class _segyioTests(TestCase):
         binary_header = _segyio.read_binaryheader(f)
         ilb = 189
         xlb = 193
-        metrics = _segyio.init_metrics(f, binary_header, ilb, xlb)
+        metrics = _segyio.init_metrics(f, binary_header)
+        metrics.update(_segyio.init_cube_metrics(f, ilb, xlb,
+                                                 metrics['trace_count'],
+                                                 metrics['trace0'],
+                                                 metrics['trace_bsize']))
         _segyio.close(f)
 
         sorting = metrics['sorting']
@@ -162,18 +166,24 @@ class _segyioTests(TestCase):
         xlb = 193
 
         with self.assertRaises(TypeError):
-            metrics = _segyio.init_metrics("?", binary_header, ilb, xlb)
+            metrics = _segyio.init_metrics("?", binary_header)
 
         with self.assertRaises(TypeError):
-            metrics = _segyio.init_metrics(f, "?", ilb, xlb)
+            metrics = _segyio.init_metrics(f, "?")
 
         with self.assertRaises(IndexError):
-            metrics = _segyio.init_metrics(f, binary_header, ilb + 1, xlb)
+            metrics = _segyio.init_metrics(f, binary_header)
+            metrics.update(_segyio.init_cube_metrics(f, ilb + 1, xlb,
+                                                     metrics['trace_count'],
+                                                     metrics['trace0'],
+                                                     metrics['trace_bsize']))
 
-        metrics = _segyio.init_metrics(f, binary_header, ilb, xlb)
+        metrics = _segyio.init_metrics(f, binary_header)
+        metrics.update(_segyio.init_cube_metrics(f, ilb, xlb,
+                                                 metrics['trace_count'],
+                                                 metrics['trace0'],
+                                                 metrics['trace_bsize']))
 
-        self.assertEqual(metrics['iline_field'], ilb)
-        self.assertEqual(metrics['xline_field'], xlb)
         self.assertEqual(metrics['trace0'], _segyio.textheader_size() + _segyio.binheader_size())
         self.assertEqual(metrics['sample_count'], 50)
         self.assertEqual(metrics['format'], 1)
@@ -187,7 +197,7 @@ class _segyioTests(TestCase):
         _segyio.close(f)
 
         with self.assertRaises(IOError):
-            metrics = _segyio.init_metrics(f, binary_header, ilb, xlb)
+            metrics = _segyio.init_metrics(f, binary_header)
 
     def test_indices(self):
         f = _segyio.open(self.filename, "r")
@@ -195,7 +205,7 @@ class _segyioTests(TestCase):
         binary_header = _segyio.read_binaryheader(f)
         ilb = 189
         xlb = 193
-        metrics = _segyio.init_metrics(f, binary_header, ilb, xlb)
+        metrics = _segyio.init_metrics(f, binary_header)
         dmy = numpy.zeros(2, dtype=numpy.intc)
 
         dummy_metrics = {'xline_count':   2,
@@ -233,6 +243,11 @@ class _segyioTests(TestCase):
         with self.assertRaises(ValueError):
             _segyio.init_indices(f, dummy_metrics, two, one, off)
 
+        metrics.update(_segyio.init_cube_metrics(f, ilb, xlb,
+                                                 metrics['trace_count'],
+                                                 metrics['trace0'],
+                                                 metrics['trace_bsize']))
+
         # Happy Path
         iline_indexes = numpy.zeros(metrics['iline_count'], dtype=numpy.intc)
         xline_indexes = numpy.zeros(metrics['xline_count'], dtype=numpy.intc)
@@ -252,7 +267,11 @@ class _segyioTests(TestCase):
         ilb = 189
         xlb = 193
 
-        metrics = _segyio.init_metrics(f, binary_header, ilb, xlb)
+        metrics = _segyio.init_metrics(f, binary_header)
+        metrics.update(_segyio.init_cube_metrics(f, ilb, xlb,
+                                                 metrics['trace_count'],
+                                                 metrics['trace0'],
+                                                 metrics['trace_bsize']))
 
         sorting = metrics['sorting']
         trace_count = metrics['trace_count']
@@ -318,7 +337,7 @@ class _segyioTests(TestCase):
             binary_header = _segyio.read_binaryheader(f)
             ilb = 189
             xlb = 193
-            metrics = _segyio.init_metrics(f, binary_header, ilb, xlb)
+            metrics = _segyio.init_metrics(f, binary_header)
 
             empty = _segyio.empty_traceheader()
 
@@ -384,7 +403,11 @@ class _segyioTests(TestCase):
         ilb = 189
         xlb = 193
 
-        metrics = _segyio.init_metrics(f, binary_header, ilb, xlb)
+        metrics = _segyio.init_metrics(f, binary_header)
+        metrics.update(_segyio.init_cube_metrics(f, ilb, xlb,
+                                                 metrics['trace_count'],
+                                                 metrics['trace0'],
+                                                 metrics['trace_bsize']))
 
         sorting = metrics['sorting']
         trace_count = metrics['trace_count']


### PR DESCRIPTION
Support opening files without a reasonable geometry, or that are in some
other way unsorted. Opens up a use case where segyio is used to read
files not yet stacked, organised by lines, but still has useful
properties or interesting data.

The default behaviour is to assume a file is sorted, and raise an
exception if this cannot be figured out.

--

If anyone have any ideas on a better exception to throw than ValueError when accessing structured properties (iline, xline, depth) on an unstructured file, please voice it. I *think* it's the best one, but it feels a bit iffy still.