### PR TITLE
file.samples is list; samples are not always time

### DIFF
--- a/lib/include/segyio/segy.h
+++ b/lib/include/segyio/segy.h
@@ -53,7 +53,7 @@ int segy_write_binheader( segy_file*, const char* buf );
  * allocates 2 octets for this, so it comfortably sits inside an int
  */
 int segy_samples( const char* binheader );
-int segy_sample_interval( segy_file*, float* dt );
+int segy_sample_interval( segy_file*, float fallback , float* dt );
 /* exception: the int returned is an enum, SEGY_SORTING, not an error code */
 int segy_format( const char* binheader );
 int segy_get_field( const char* traceheader, int field, int32_t* f );

--- a/mex/SegySpec.m
+++ b/mex/SegySpec.m
@@ -33,7 +33,7 @@ classdef SegySpec
 
             obj.sample_format = uint32(SegySampleFormat(spec.sample_format));
             obj.trace_sorting_format = TraceSortingFormat(spec.trace_sorting_format);
-            obj.sample_indexes = spec.sample_indexes;
+            obj.sample_indexes = ((spec.sample_indexes - t0) / 1000.0) + t0;
             obj.crossline_indexes = uint32(spec.crossline_indexes);
             obj.inline_indexes = uint32(spec.inline_indexes);
             obj.offset_count = uint32(spec.offset_count);

--- a/python/examples/copy-sub-cube.py
+++ b/python/examples/copy-sub-cube.py
@@ -14,7 +14,7 @@ def main():
         spec = segyio.spec()
         spec.sorting = int(src.sorting)
         spec.format  = int(src.format)
-        spec.samples = 50
+        spec.samples = range(50)
         spec.ilines = src.ilines[:5]
         spec.xlines = src.xlines[:5]
 

--- a/python/examples/make-file.py
+++ b/python/examples/make-file.py
@@ -16,7 +16,7 @@ def main():
     # the absolute minimal specification for a N-by-M volume
     spec.sorting = 2
     spec.format = 1
-    spec.samples = int(sys.argv[2])
+    spec.samples = range(int(sys.argv[2]))
     spec.ilines = range(*map(int, sys.argv[3:5]))
     spec.xlines = range(*map(int, sys.argv[5:7]))
 
@@ -31,13 +31,13 @@ def main():
         # looking up an inline's i's jth crosslines' k should be roughly equal
         # to i.j0k
         trace = np.arange(start = start,
-                          stop  = start + step * spec.samples,
+                          stop  = start + step * len(spec.samples),
                           step  = step,
                           dtype = np.single)
 
         # one inline is N traces concatenated. We fill in the xline number
         line = np.concatenate([trace + (xl / 100.0) for xl in spec.xlines])
-        line = line.reshape( (len(spec.xlines), spec.samples) )
+        line = line.reshape( (len(spec.xlines), len(spec.samples)) )
 
         # write the line itself to the file
         # write the inline number in all this line's headers

--- a/python/examples/make-ps-file.py
+++ b/python/examples/make-ps-file.py
@@ -20,7 +20,7 @@ def main():
     # N-by-M volume with K offsets volume
     spec.sorting = 2
     spec.format = 1
-    spec.samples = int(sys.argv[2])
+    spec.samples = range(int(sys.argv[2]))
     spec.ilines = range(*map(int, sys.argv[3:5]))
     spec.xlines = range(*map(int, sys.argv[5:7]))
     spec.offsets = range(*map(int, sys.argv[7:9]))
@@ -37,14 +37,14 @@ def main():
         # looking up an inline's i's jth crosslines' k should be roughly equal
         # to (offset*100) + i.j0k.
         trace = np.arange(start = start,
-                          stop  = start + step * spec.samples,
+                          stop  = start + step * len(spec.samples),
                           step  = step,
                           dtype = np.single)
 
         nx, no = len(spec.xlines), len(spec.offsets)
         # one inline is N traces concatenated. We fill in the xline number
         line = np.concatenate([trace + (xl / 100.0) for xl in spec.xlines])
-        line = line.reshape( (nx, spec.samples) )
+        line = line.reshape( (nx, len(spec.samples)) )
 
         for ilindex, ilno in enumerate(spec.ilines):
             iline = line + ilno

--- a/python/segyio/_raw_trace.py
+++ b/python/segyio/_raw_trace.py
@@ -13,7 +13,7 @@ class RawTrace(object):
             start, stop, step = index.indices(f.tracecount)
             mstart, mstop = min(start, stop), max(start, stop)
             length = max(0, (mstop - mstart + (step - (1 if step > 0 else -1))))
-            buf = np.zeros(shape = (length, f.samples), dtype = np.single)
+            buf = np.zeros(shape = (length, len(f.samples)), dtype = np.single)
 
         return self.trace._readtr(index, buf)
 

--- a/python/segyio/_segyio.c
+++ b/python/segyio/_segyio.c
@@ -615,17 +615,17 @@ static PyObject *py_get_dt(PyObject *self, PyObject *args) {
     errno = 0;
 
     PyObject *file_capsule = NULL;
-    float dt;
-    PyArg_ParseTuple(args, "Of", &file_capsule, &dt);
+    float fallback;
+    PyArg_ParseTuple(args, "Of", &file_capsule, &fallback);
     segy_file *p_FILE = get_FILE_pointer_from_capsule(file_capsule);
 
     if (PyErr_Occurred()) { return NULL; }
 
-    int error = segy_sample_interval(p_FILE, &dt);
+    float dt;
+    int error = segy_sample_interval(p_FILE, fallback, &dt);
     if (error != 0) { return py_handle_segy_error(error, errno); }
 
-    double ddt = dt;
-    return PyFloat_FromDouble(ddt);
+    return PyFloat_FromDouble( dt );
 }
 
 

--- a/python/segyio/_trace.py
+++ b/python/segyio/_trace.py
@@ -41,7 +41,7 @@ class Trace:
         if val.dtype != np.single:
             raise TypeError("Numpy array must be of type single")
 
-        shape = (self._file.samples,)
+        shape = (len(self._file.samples),)
 
         if val.shape[0] < shape[0]:
             raise TypeError("Array wrong shape. Expected minimum %s, was %s" % (shape, val.shape))
@@ -66,14 +66,14 @@ class Trace:
         return "Trace(traces = {}, samples = {})".format(len(self), self._file.samples)
 
     def _trace_buffer(self, buf=None):
-        samples = self._file.samples
+        shape = self._file.samples.shape
 
         if buf is None:
-            buf = np.empty(shape=samples, dtype=np.single)
+            buf = np.empty(shape=shape, dtype=np.single)
         elif not isinstance(buf, np.ndarray):
             raise TypeError("Buffer must be None or numpy.ndarray")
         elif buf.dtype != np.single:
-            buf = np.empty(shape=samples, dtype=np.single)
+            buf = np.empty(shape=shape, dtype=np.single)
 
         return buf
 
@@ -84,8 +84,8 @@ class Trace:
         trace0 = self._file._tr0
         bsz = self._file._bsz
         fmt = self._file._fmt
-        samples = self._file.samples
-        return segyio._segyio.read_trace(self._file.xfd, traceno, tracecount, buf, trace0, bsz, fmt, samples)
+        smp = len(self._file.samples)
+        return segyio._segyio.read_trace(self._file.xfd, traceno, tracecount, buf, trace0, bsz, fmt, smp)
 
     def _writetr(self, traceno, buf):
         self.write_trace(traceno, buf, self._file)
@@ -97,7 +97,10 @@ class Trace:
         :type buf: ?
         :type segy: segyio.SegyFile
         """
-        segyio._segyio.write_trace(segy.xfd, traceno, buf, segy._tr0, segy._bsz, segy._fmt, segy.samples)
+        segyio._segyio.write_trace(segy.xfd, traceno,
+                                   buf,
+                                   segy._tr0, segy._bsz,
+                                   segy._fmt, len(segy.samples))
 
     @property
     def raw(self):

--- a/python/segyio/create.py
+++ b/python/segyio/create.py
@@ -45,7 +45,7 @@ def create(filename, spec):
             >>> spec = segyio.spec()
             >>> spec.ilines  = [1, 2, 3, 4]
             >>> spec.xlines  = [11, 12, 13]
-            >>> spec.samples = 50
+            >>> spec.samples = list(range(50))
             >>> spec.sorting = 2
             >>> spec.format  = 1
             >>> with segyio.create(path, spec) as f:
@@ -57,7 +57,7 @@ def create(filename, spec):
             ...     spec = segyio.spec()
             ...     spec.sorting = src.sorting
             ...     spec.format = src.format
-            ...     spec.samples = src.samples - 50
+            ...     spec.samples = src.samples[:len(src.samples) - 50]
             ...     spec.ilines = src.ilines
             ...     spec.xline = src.xlines
             ...     with segyio.create(dstpath, spec) as dst:
@@ -69,9 +69,9 @@ def create(filename, spec):
     """
     f = segyio.SegyFile(filename, "w+")
 
-    f._samples       = spec.samples
+    f._samples       = numpy.asarray(spec.samples, dtype = numpy.intc)
     f._ext_headers   = spec.ext_headers
-    f._bsz           = _segyio.trace_bsize(f.samples)
+    f._bsz           = _segyio.trace_bsize(len(f.samples))
 
     txt_hdr_sz       = _segyio.textheader_size()
     bin_hdr_sz       = _segyio.binheader_size()
@@ -99,7 +99,7 @@ def create(filename, spec):
     f.bin     = {
         3213: f.tracecount,
         3217: 4000,
-        3221: f.samples,
+        3221: len(f.samples),
         3225: f.format,
         3505: f.ext_headers,
     }

--- a/python/segyio/open.py
+++ b/python/segyio/open.py
@@ -58,12 +58,17 @@ def open(filename, mode="r", iline=189, xline=193, strict = True):
     try:
         metrics = segyio._segyio.init_metrics(f.xfd, f.bin.buf)
 
-        f._samples = metrics['sample_count']
         f._tr0 = metrics['trace0']
         f._fmt = metrics['format']
         f._bsz = metrics['trace_bsize']
-        f._ext_headers = (f._tr0 - 3600) // 3200  # should probably be from C
         f._tracecount = metrics['trace_count']
+        f._ext_headers = (f._tr0 - 3600) // 3200  # should probably be from C
+
+        dt = segyio.tools.dt(f, fallback_dt = 4000.0)
+        t0 = f.header[0][segyio.TraceField.DelayRecordingTime]
+        sample_count = metrics['sample_count']
+        f._samples = numpy.array([t0 + i * dt for i in range(sample_count)],
+                                 dtype = numpy.intc)
 
     except:
         f.close()

--- a/python/segyio/segy.py
+++ b/python/segyio/segy.py
@@ -477,12 +477,16 @@ class SegyFile(object):
         return buf
 
     def _line_buffer(self, length, buf=None):
-        shape = (length, self.samples)
+        shape = (length, len(self.samples))
         return self._shape_buffer(shape, buf)
 
     def _fread_line(self, trace0, length, stride, buf):
         offsets = len(self.offsets)
-        return _segyio.read_line(self.xfd, trace0, length, stride, offsets, buf, self._tr0, self._bsz, self._fmt, self.samples)
+        return _segyio.read_line(self.xfd, trace0,
+                                length, stride, offsets,
+                                buf,
+                                self._tr0, self._bsz,
+                                self._fmt, len(self.samples))
 
     @property
     def ilines(self):
@@ -856,8 +860,8 @@ class SegyFile(object):
         if self.unstructured:
             raise ValueError(self._unstructured_errmsg)
 
-        indices = np.asarray(list(range(self.samples)), dtype=np.uintc)
-        other_indices = np.asarray([0], dtype=np.uintc)
+        indices = np.asarray(list(range(len(self.samples))), dtype=np.intc)
+        other_indices = np.asarray([0], dtype=np.intc)
         buffn = self._depth_buffer
 
         slice_trace_count = self._iline_length * self._xline_length
@@ -865,10 +869,14 @@ class SegyFile(object):
         tr0 = self._tr0
         bsz = self._bsz
         fmt = self._fmt
-        samples = self.samples
 
         def readfn(depth, length, stride, buf):
-            _segyio.depth_slice(self.xfd, depth, slice_trace_count, offsets, buf, tr0, bsz, fmt, samples)
+            _segyio.depth_slice(self.xfd, depth,
+                                slice_trace_count, offsets,
+                                buf,
+                                tr0, bsz,
+                                fmt,
+                                len(self.samples))
             return buf
 
         def writefn(depth, length, stride, val):
@@ -880,7 +888,7 @@ class SegyFile(object):
                 trace_buf[depth] = buf_view[i]
                 self.trace[i] = trace_buf
 
-        return Line(self, self.samples, 1, indices, other_indices, buffn, readfn, writefn, "Depth")
+        return Line(self, len(self.samples), 1, indices, other_indices, buffn, readfn, writefn, "Depth")
 
     @depth_slice.setter
     def depth_slice(self, value):

--- a/python/segyio/tools.py
+++ b/python/segyio/tools.py
@@ -27,7 +27,7 @@ def sample_indexes(segyfile, t0=0.0, dt_override=None):
     if dt_override is None:
         dt_override = dt(segyfile)
 
-    return [t0 + t * dt_override for t in range(segyfile.samples)]
+    return [t0 + t * dt_override for t in range(len(segyfile.samples))]
 
 
 def create_text_header(lines):
@@ -117,6 +117,7 @@ def cube(f):
     ilsort = f.sorting == segyio.TraceSortingFormat.INLINE_SORTING
     fast = f.ilines if ilsort else f.xlines
     slow = f.xlines if ilsort else f.ilines
-    fast, slow, offs, samples = len(fast), len(slow), len(f.offsets), f.samples
-    dims = (fast, slow, samples) if offs == 1 else (fast, slow, offs, samples)
+    fast, slow, offs = len(fast), len(slow), len(f.offsets)
+    smps = len(f.samples)
+    dims = (fast, slow, smps) if offs == 1 else (fast, slow, offs, smps)
     return f.trace.raw[:].reshape(dims)

--- a/python/test/tools.py
+++ b/python/test/tools.py
@@ -43,13 +43,13 @@ class ToolsTest(TestCase):
     def test_sample_indexes(self):
         with segyio.open(self.filename, "r") as f:
             indexes = segyio.sample_indexes(f)
-            self.assertListEqual(indexes, [t * 4.0 for t in range(f.samples)])
+            self.assertListEqual(indexes, [t * 4.0 for t in range(len(f.samples))])
 
             indexes = segyio.sample_indexes(f, t0=1.5)
-            self.assertListEqual(indexes, [1.5 + t * 4.0 for t in range(f.samples)])
+            self.assertListEqual(indexes, [1.5 + t * 4.0 for t in range(len(f.samples))])
 
             indexes = segyio.sample_indexes(f, t0=1.5, dt_override=3.21)
-            self.assertListEqual(indexes, [1.5 + t * 3.21 for t in range(f.samples)])
+            self.assertListEqual(indexes, [1.5 + t * 3.21 for t in range(len(f.samples))])
 
     def test_empty_text_header_creation(self):
         text_header = segyio.create_text_header({})
@@ -69,7 +69,7 @@ class ToolsTest(TestCase):
     def test_native(self):
         with open(self.filename, 'rb') as f, segyio.open(self.filename) as sgy:
             f.read(3600+240)
-            filetr = f.read(4 * sgy.samples)
+            filetr = f.read(4 * len(sgy.samples))
             segytr = sgy.trace[0]
 
             filetr = np.frombuffer(filetr, dtype = np.single)
@@ -85,11 +85,11 @@ class ToolsTest(TestCase):
     def test_cube_identity(self):
         with segyio.open(self.filename) as f:
             x = segyio.tools.collect(f.trace[:])
-            x = x.reshape((len(f.ilines), len(f.xlines), f.samples))
+            x = x.reshape((len(f.ilines), len(f.xlines), len(f.samples)))
             self.assertTrue(np.all(x == segyio.tools.cube(f)))
 
     def test_cube_identity_prestack(self):
         with segyio.open(self.prestack) as f:
-            dims = (len(f.ilines), len(f.xlines), len(f.offsets), f.samples)
+            dims = (len(f.ilines), len(f.xlines), len(f.offsets), len(f.samples))
             x = segyio.tools.collect(f.trace[:]).reshape(dims)
             self.assertTrue(np.all(x == segyio.tools.cube(f)))

--- a/python/test/tools.py
+++ b/python/test/tools.py
@@ -38,15 +38,16 @@ class ToolsTest(TestCase):
                 f.bin[BinField.Interval] = dt_us
                 f.header[0][TraceField.TRACE_SAMPLE_INTERVAL] = dt_us
                 f.flush()
-                np.testing.assert_almost_equal(segyio.dt(f), dt_us / 1000)
+                np.testing.assert_almost_equal(segyio.dt(f), dt_us)
 
     def test_sample_indexes(self):
         with segyio.open(self.filename, "r") as f:
             indexes = segyio.sample_indexes(f)
-            self.assertListEqual(indexes, [t * 4.0 for t in range(len(f.samples))])
+            step = 4000.0
+            self.assertListEqual(indexes, [t * step for t in range(len(f.samples))])
 
             indexes = segyio.sample_indexes(f, t0=1.5)
-            self.assertListEqual(indexes, [1.5 + t * 4.0 for t in range(len(f.samples))])
+            self.assertListEqual(indexes, [1.5 + t * step for t in range(len(f.samples))])
 
             indexes = segyio.sample_indexes(f, t0=1.5, dt_override=3.21)
             self.assertListEqual(indexes, [1.5 + t * 3.21 for t in range(len(f.samples))])
@@ -93,3 +94,22 @@ class ToolsTest(TestCase):
             dims = (len(f.ilines), len(f.xlines), len(f.offsets), len(f.samples))
             x = segyio.tools.collect(f.trace[:]).reshape(dims)
             self.assertTrue(np.all(x == segyio.tools.cube(f)))
+
+    def test_scale_samples(self):
+        with segyio.open(self.filename) as f:
+            samples, unit = segyio.tools.scale_samples(f.samples)
+            self.assertEqual('ms', unit)
+            self.assertListEqual([4.0 * i for i in range(len(samples))],
+                                 list(samples))
+
+            meters = [10 * i for i in range(len(samples))]
+            f._samples = np.array(meters)
+            samples, unit = segyio.tools.scale_samples(f.samples)
+            self.assertEqual('m', unit)
+            self.assertListEqual(meters, list(samples))
+
+    def test_scale_samples_pylist(self):
+        sampleslist = [10 * i for i in range(10)]
+        samplesnp = np.array(sampleslist)
+        eq = np.all(samplesnp == segyio.tools.scale_samples(samplesnp)[0])
+        self.assertTrue(eq)


### PR DESCRIPTION
Analoguous to file.xlines, file.ilines, file.samples is now a list of
samples and their identifiers. If possible, this is a list derived from
the binary- and trace headers with a recording delay t0 and a sample
interval. If these can't be figured out they're assumed to be 0 and
4000μs, 4ms, respectively.

As with the other identifiers, the cardinality is now obtained with
len().

The segy_sample_interval function would always assume that the interval
between sample describes distance-in-time (ms), but this is means a loss
of information when the data was in meters (which would be interpreted
as millimeters). Instead, this function now returns the inferred
interval without modifications, leaving it up to the caller to determine
what the interval describes, and typically has more information
available.

This means that the sample_indexes function in python.tools now changes
behaviour and uses microseconds (as per the specification) rather than
milliseconds. To support the typical use of this function,
segyio.tools.scale_samples has been added. This function uses heuristics
to determine if the sample interval is in distance (meters) or time
(milliseconds), scales the samples accordingly and returns a tuple of
samples and their units.