### PR TITLE
Remove scale_samples; store samples as float

### DIFF
--- a/python/segyio/create.py
+++ b/python/segyio/create.py
@@ -69,7 +69,7 @@ def create(filename, spec):
     """
     f = segyio.SegyFile(filename, "w+")
 
-    f._samples       = numpy.asarray(spec.samples, dtype = numpy.intc)
+    f._samples       = numpy.asarray(spec.samples, dtype = numpy.single)
     f._ext_headers   = spec.ext_headers
     f._bsz           = _segyio.trace_bsize(len(f.samples))
 

--- a/python/segyio/open.py
+++ b/python/segyio/open.py
@@ -68,7 +68,7 @@ def open(filename, mode="r", iline=189, xline=193, strict = True):
         t0 = f.header[0][segyio.TraceField.DelayRecordingTime]
         sample_count = metrics['sample_count']
         f._samples = numpy.array([t0 + i * dt for i in range(sample_count)],
-                                 dtype = numpy.intc)
+                                 dtype = numpy.single) / 1000.0
 
     except:
         f.close()

--- a/python/segyio/tools.py
+++ b/python/segyio/tools.py
@@ -121,33 +121,3 @@ def cube(f):
     smps = len(f.samples)
     dims = (fast, slow, smps) if offs == 1 else (fast, slow, offs, smps)
     return f.trace.raw[:].reshape(dims)
-
-def scale_samples(samples):
-    """ Guess unit and scale of the sample intervals
-
-    :type samples: iterable[int]
-    :rtype: tuple[numpy.ndarray,str]
-
-    Attempt to figure out if the sample values represent depth (in meters) or
-    time (in milliseconds).
-    """
-
-    samples = np.array(samples)
-
-    # this is VERY unlikely, but in the case of a file with only one sample per
-    # trace, assume depth (meter)
-    if len(samples) == 1:
-        return (samples, 'm')
-
-    # heuristic: since the spec suggests microseconds for step between samples,
-    # and 4ms is *very* common for step size, any large difference between two
-    # values probably means that the unit is time. A step size of 100 meters is
-    # quite unlikely, but this threshold is arbitrary and might require tuning
-    # in the future
-    depth = abs(samples[0] - samples[1]) < 100
-
-    if not depth:
-        samples = samples / 1000
-
-    unit = 'm' if depth else 'ms'
-    return (samples, unit)

--- a/python/test/tools.py
+++ b/python/test/tools.py
@@ -94,22 +94,3 @@ class ToolsTest(TestCase):
             dims = (len(f.ilines), len(f.xlines), len(f.offsets), len(f.samples))
             x = segyio.tools.collect(f.trace[:]).reshape(dims)
             self.assertTrue(np.all(x == segyio.tools.cube(f)))
-
-    def test_scale_samples(self):
-        with segyio.open(self.filename) as f:
-            samples, unit = segyio.tools.scale_samples(f.samples)
-            self.assertEqual('ms', unit)
-            self.assertListEqual([4.0 * i for i in range(len(samples))],
-                                 list(samples))
-
-            meters = [10 * i for i in range(len(samples))]
-            f._samples = np.array(meters)
-            samples, unit = segyio.tools.scale_samples(f.samples)
-            self.assertEqual('m', unit)
-            self.assertListEqual(meters, list(samples))
-
-    def test_scale_samples_pylist(self):
-        sampleslist = [10 * i for i in range(10)]
-        samplesnp = np.array(sampleslist)
-        eq = np.all(samplesnp == segyio.tools.scale_samples(samplesnp)[0])
-        self.assertTrue(eq)


### PR DESCRIPTION
The heuristic that separates between time/depth is broken, since the
sample rate for depth is millimeters, not meters. In other words, it is
impossible to figure out just by inspecting the file if sample interval
means time or depth. The entire tool is removed in favour of correctly
storing the samples as floats.