### PR TITLE
Make trace.__getitem__ accept more int-like types

### DIFF
--- a/python/segyio/_raw_trace.py
+++ b/python/segyio/_raw_trace.py
@@ -1,6 +1,11 @@
 import numpy as np
 import segyio
 
+try: xrange
+except NameError: pass
+else: range = xrange
+
+
 class RawTrace(object):
     def __init__(self, trace):
         self.trace = trace
@@ -14,8 +19,13 @@ class RawTrace(object):
             mstart, mstop = min(start, stop), max(start, stop)
             length = max(0, (mstop - mstart + (step - (1 if step > 0 else -1))))
             buf = np.zeros(shape = (length, len(f.samples)), dtype = np.single)
+            l = len(range(start, stop, step))
+            return self.trace._readtr(start, step, l, buf)
 
-        return self.trace._readtr(index, buf)
+        if int(index) != index:
+            raise TypeError("Trace index must be integer or slice.")
+
+        return self.trace._readtr(int(index), 1, 1, buf)
 
     def __repr__(self):
         return self.trace.__repr__() + ".raw"

--- a/python/test/segy.py
+++ b/python/test/segy.py
@@ -572,6 +572,17 @@ class TestSegy(TestCase):
             self.assertListEqual(list(f.attributes(189)[:]),
                                  [(i // 5) + 1 for i in range(len(f.trace))])
 
+    def test_traceaccess_from_array(self):
+        a = np.arange(10, dtype = np.int)
+        b = np.arange(10, dtype = np.int32)
+        c = np.arange(10, dtype = np.int64)
+        d = np.arange(10, dtype = np.intc)
+        with segyio.open(self.filename) as f:
+            f.trace[a[0]]
+            f.trace[b[1]]
+            f.trace[c[2]]
+            f.trace[d[3]]
+
     def test_create_sgy(self):
         with TestContext("create_sgy") as context:
             context.copy_file(self.filename)

--- a/python/test/segyio_c.py
+++ b/python/test/segyio_c.py
@@ -383,12 +383,12 @@ class _segyioTests(TestCase):
 
             buf = numpy.zeros(25, dtype=numpy.single)
 
-            _segyio.read_trace(f, 0, 25, buf, 0, 100, 1, 25)
+            _segyio.read_trace(f, buf, 0, 1, 1, 1, 25, 0, 100)
 
             self.assertAlmostEqual(buf[10], 1.0, places=4)
             self.assertAlmostEqual(buf[11], 3.1415, places=4)
 
-            _segyio.read_trace(f, 1, 25, buf, 0, 100, 1, 25)
+            _segyio.read_trace(f, buf, 1, 1, 1, 1, 25, 0, 100)
 
             self.assertAlmostEqual(sum(buf), 42.0 * 25, places=4)
 


### PR DESCRIPTION
Under some conditions, perfectly fine int-like types would raise a type
error when passed to getitem. Instead of checking for isinstance(int),
a slice or an int-like type is expected, and we internally handle the
conversion to an actual int.