### PR TITLE
Make generator read-ops exception safe

### DIFF
--- a/python/segyio/_header.py
+++ b/python/segyio/_header.py
@@ -55,7 +55,7 @@ class Header(object):
     def __repr__(self):
         return "Header(traces = {})".format(self.segy.samples)
 
-    def readfn(self, t0, length, stride, buf):
+    def readfn(self, t0, length, stride, *_):
         def gen():
             buf1, buf2 = self._header_buffer(), self._header_buffer()
             start = t0

--- a/python/segyio/_line.py
+++ b/python/segyio/_line.py
@@ -110,9 +110,12 @@ class Line:
 
     def _get_iter(self, lineno, off, buf):
         """ :rtype: collections.Iterable[numpy.ndarray]"""
+        buf1, buf2 = buf, self.buffn()
 
         for line, offset in itertools.product(*self._indices(lineno, off)):
-            yield self._get(line, offset, buf)
+            buf1 = self._get(line, offset, buf1)
+            buf2, buf1 = buf1, buf2
+            yield buf2
 
     def __getitem__(self, lineno, offset=None):
         """ :rtype: numpy.ndarray|collections.Iterable[numpy.ndarray]"""

--- a/python/segyio/_raw_trace.py
+++ b/python/segyio/_raw_trace.py
@@ -20,12 +20,14 @@ class RawTrace(object):
             length = max(0, (mstop - mstart + (step - (1 if step > 0 else -1))))
             buf = np.zeros(shape = (length, len(f.samples)), dtype = np.single)
             l = len(range(start, stop, step))
-            return self.trace._readtr(start, step, l, buf)
+            buf, _ = self.trace._readtr(start, step, l, buf)
+            return buf
 
         if int(index) != index:
             raise TypeError("Trace index must be integer or slice.")
 
-        return self.trace._readtr(int(index), 1, 1, buf)
+        buf = self.trace._trace_buffer(None)
+        return self.trace._readtr(int(index), 1, 1, buf)[0]
 
     def __repr__(self):
         return self.trace.__repr__() + ".raw"


### PR DESCRIPTION
Instead of reading directly from file into arrays or buffers that might
already be given to users, read into secondary arrays. This way, when a
read operation fails, user arrays will not be corrupted.