### PR TITLE
Implement line_indices with field_forall

### DIFF
--- a/lib/src/segy.c
+++ b/lib/src/segy.c
@@ -963,20 +963,14 @@ static int segy_line_indices( segy_file* fp,
                               int* buf,
                               long trace0,
                               int trace_bsize ) {
-
-    if( field_size[ field ] == 0 )
-        return SEGY_INVALID_FIELD;
-
-    char header[ SEGY_TRACE_HEADER_SIZE ];
-    for( ; num_indices--; traceno += stride, ++buf ) {
-
-        int err = segy_traceheader( fp, traceno, header, trace0, trace_bsize );
-        if( err != 0 ) return SEGY_FREAD_ERROR;
-
-        segy_get_field( header, field, buf );
-    }
-
-    return SEGY_OK;
+    return segy_field_forall( fp,
+                              field,
+                              traceno,                          /* start */
+                              traceno + (num_indices * stride), /* stop */
+                              stride,                           /* step */
+                              buf,
+                              trace0,
+                              trace_bsize );
 }
 
 static int count_lines( segy_file* fp,


### PR DESCRIPTION
Turns out the line_indices function was an early version of the
field_forall function, so it might as well be an alias for it. It reads
less from every trace, so it should be faster in most cases.