### PR TITLE
Interpret delay recording time/t0 as milliseconds

### DIFF
--- a/mex/SegySpec.m
+++ b/mex/SegySpec.m
@@ -33,7 +33,7 @@ classdef SegySpec
 
             obj.sample_format = uint32(SegySampleFormat(spec.sample_format));
             obj.trace_sorting_format = TraceSortingFormat(spec.trace_sorting_format);
-            obj.sample_indexes = ((spec.sample_indexes - t0) / 1000.0) + t0;
+            obj.sample_indexes = spec.sample_indexes / 1000.0;
             obj.crossline_indexes = uint32(spec.crossline_indexes);
             obj.inline_indexes = uint32(spec.inline_indexes);
             obj.offset_count = uint32(spec.offset_count);

--- a/python/segyio/open.py
+++ b/python/segyio/open.py
@@ -75,11 +75,10 @@ def open(filename, mode="r", iline = 189,
         f._tracecount = metrics['trace_count']
         f._ext_headers = (f._tr0 - 3600) // 3200  # should probably be from C
 
-        dt = segyio.tools.dt(f, fallback_dt = 4000.0)
+        dt = segyio.tools.dt(f, fallback_dt = 4000.0) / 1000.0
         t0 = f.header[0][segyio.TraceField.DelayRecordingTime]
-        sample_count = metrics['sample_count']
-        f._samples = numpy.array([t0 + i * dt for i in range(sample_count)],
-                                 dtype = numpy.single) / 1000.0
+        samples = metrics['sample_count']
+        f._samples = (numpy.arange(samples, dtype = numpy.single) * dt) + t0
 
     except:
         f.close()

--- a/python/segyio/tools.py
+++ b/python/segyio/tools.py
@@ -3,7 +3,7 @@ import numpy as np
 import itertools as itr
 
 
-def dt(segyfile, fallback_dt=4000):
+def dt(segyfile, fallback_dt=4000.0):
     """
     Find a *dt* value in the SegyFile. If none is found use the provided *fallback_dt* value.
 


### PR DESCRIPTION
Correctly compute samples by interpreting t0 as milliseconds, not
microseconds.