### PR TITLE
Added text header formatting output in segyio.tools

### DIFF
--- a/python/segyio/tools.py
+++ b/python/segyio/tools.py
@@ -1,6 +1,6 @@
 import segyio
 import numpy as np
-import itertools as itr
+import textwrap
 
 
 def dt(segyfile, fallback_dt=4000.0):
@@ -51,6 +51,17 @@ def create_text_header(lines):
 
     rows = ''.join(rows)
     return rows
+
+def wrap(s, width=80):
+    """
+    Formats the text input with newlines given the user specified width for each line
+
+    :type s: str
+    :type width: int
+    :rtype: str
+    """
+    return '\n'.join(textwrap.wrap(str(s), width=width))
+
 
 def native(data,
            format = segyio.SegySampleFormat.IBM_FLOAT_4_BYTE,

--- a/python/test/tools.py
+++ b/python/test/tools.py
@@ -59,6 +59,11 @@ class ToolsTest(TestCase):
             line = text_header[line_no * 80: (line_no + 1) * 80]
             self.assertEqual(line, "C{0:>2} {1:76}".format(line_no + 1, ""))
 
+    def test_wrap(self):
+        with segyio.open(self.filename, "r") as f:
+            segyio.tools.wrap(f.text[0])
+            segyio.tools.wrap(f.text[0], 90)
+
     def test_values_text_header_creation(self):
         lines = {i + 1: chr(64 + i) * 76 for i in range(40)}
         text_header = segyio.create_text_header(lines)


### PR DESCRIPTION
Add tools.wrap (textwrap.wrap()) to format f.text with a user specific width on each line (default 80)