### PR TITLE
Return samples in microseconds in matlab

### DIFF
--- a/mex/SegySpec.m
+++ b/mex/SegySpec.m
@@ -33,7 +33,7 @@ classdef SegySpec
 
             obj.sample_format = uint32(SegySampleFormat(spec.sample_format));
             obj.trace_sorting_format = TraceSortingFormat(spec.trace_sorting_format);
-            obj.sample_indexes = spec.sample_indexes / 1000.0;
+            obj.sample_indexes = spec.sample_indexes;
             obj.crossline_indexes = uint32(spec.crossline_indexes);
             obj.inline_indexes = uint32(spec.inline_indexes);
             obj.offset_count = uint32(spec.offset_count);


### PR DESCRIPTION
This was changed to be python compatible (i.e. return milliseconds), but
for compatibility reasons (confirmed by tests), microseconds are
returned for samples.