### PR TITLE
Correctly adjust mex/t0 argument to milliseconds

### DIFF
--- a/mex/SegySpec.m
+++ b/mex/SegySpec.m
@@ -33,7 +33,7 @@ classdef SegySpec
 
             obj.sample_format = uint32(SegySampleFormat(spec.sample_format));
             obj.trace_sorting_format = TraceSortingFormat(spec.trace_sorting_format);
-            obj.sample_indexes = spec.sample_indexes;
+            obj.sample_indexes = spec.sample_indexes / 1000.0;
             obj.crossline_indexes = uint32(spec.crossline_indexes);
             obj.inline_indexes = uint32(spec.inline_indexes);
             obj.offset_count = uint32(spec.offset_count);

--- a/mex/segyspec_mex.c
+++ b/mex/segyspec_mex.c
@@ -97,7 +97,7 @@ void mexFunction( int nlhs, mxArray *plhs[],
     double dt = mxGetScalar(prhs[4]);
 
     SegySpec spec;
-    int errc = segyCreateSpec(&spec, filename, il, xl, t0, dt);
+    int errc = segyCreateSpec(&spec, filename, il, xl, t0 * 1000.0, dt);
     if (errc != 0) {
         goto FAILURE;
     }


### PR DESCRIPTION
interpret_segycube expects its t0 argument in milliseconds, but the
underlying C functionality uses microseconds (to have consistent units
with sample rate).