### PR TITLE
Arbitrary offset header word

### DIFF
--- a/applications/segyinspect.c
+++ b/applications/segyinspect.c
@@ -96,7 +96,11 @@ int main(int argc, char* argv[]) {
     }
 
     int sorting;
-    err = segy_sorting( fp, il_field, xl_field, &sorting, trace0, trace_bsize );
+    err = segy_sorting( fp, il_field,
+                            xl_field,
+                            SEGY_TR_OFFSET,
+                            &sorting,
+                            trace0, trace_bsize );
     if( err != 0 ) {
         perror( "Could not determine sorting" );
         exit( err );

--- a/lib/include/segyio/segy.h
+++ b/lib/include/segyio/segy.h
@@ -106,13 +106,13 @@ int segy_write_traceheader( segy_file*,
                             int trace_bsize );
 
 /*
- * Number of traces in this file. The sorting type will be written to `sorting`
- * if the function can figure out how the file is sorted. If not, some error
- * code will be returned and `out` will not be modified.
+ * The sorting type will be written to `sorting` if the function can figure out
+ * how the file is sorted.
  */
 int segy_sorting( segy_file*,
                   int il,
                   int xl,
+                  int tr_offset,
                   int* sorting,
                   long trace0,
                   int trace_bsize );

--- a/lib/include/segyio/segy.h
+++ b/lib/include/segyio/segy.h
@@ -45,7 +45,7 @@ int segy_close( segy_file* );
  * The binheader buffer passed to these functions must be of *at least*
  * `segy_binheader_size`. Returns size, not an error code.
  */
-int segy_binheader_size();
+int segy_binheader_size( void );
 int segy_binheader( segy_file*, char* buf );
 int segy_write_binheader( segy_file*, const char* buf );
 /*
@@ -88,7 +88,7 @@ int segy_sample_indices( segy_file*,
 
 /* text header operations */
 int segy_read_textheader( segy_file*, char *buf);
-int segy_textheader_size();
+int segy_textheader_size( void );
 int segy_write_textheader( segy_file*, int pos, const char* buf );
 
 /* Read the trace header at `traceno` into `buf`. */

--- a/lib/src/segy.c
+++ b/lib/src/segy.c
@@ -1537,10 +1537,10 @@ int segy_write_textheader( segy_file* fp, int pos, const char* buf ) {
     return SEGY_OK;
 }
 
-int segy_textheader_size() {
+int segy_textheader_size( void ) {
     return SEGY_TEXT_HEADER_SIZE + 1;
 }
 
-int segy_binheader_size() {
+int segy_binheader_size( void ) {
     return SEGY_BINARY_HEADER_SIZE;
 }

--- a/lib/src/segy.c
+++ b/lib/src/segy.c
@@ -824,6 +824,7 @@ int segy_sample_indices( segy_file* fp,
 int segy_sorting( segy_file* fp,
                   int il,
                   int xl,
+                  int tr_offset,
                   int* sorting,
                   long trace0,
                   int trace_bsize ) {
@@ -847,7 +848,7 @@ int segy_sorting( segy_file* fp,
 
     segy_get_field( traceheader, il, &il0 );
     segy_get_field( traceheader, xl, &xl0 );
-    segy_get_field( traceheader, SEGY_TR_OFFSET, &off0 );
+    segy_get_field( traceheader, tr_offset, &off0 );
 
     int traces;
     err = segy_traces( fp, &traces, trace0, trace_bsize );
@@ -860,7 +861,7 @@ int segy_sorting( segy_file* fp,
 
         segy_get_field( traceheader, il, &il1 );
         segy_get_field( traceheader, xl, &xl1 );
-        segy_get_field( traceheader, SEGY_TR_OFFSET, &off1 );
+        segy_get_field( traceheader, tr_offset, &off1 );
         ++traceno;
     } while( off0 != off1 && traceno < traces );
 

--- a/lib/test/segy.c
+++ b/lib/test/segy.c
@@ -23,6 +23,7 @@ static void test_interpret_file() {
     int line_trace0, line_length;
     const int il = SEGY_TR_INLINE;
     const int xl = SEGY_TR_CROSSLINE;
+    const int of = SEGY_TR_OFFSET;
 
     segy_file* fp = segy_open( file, "rb" );
 
@@ -45,11 +46,11 @@ static void test_interpret_file() {
     assertTrue( err == 0, "Could not determine number of traces in this file." );
     assertTrue( traces == 25, "Expected 25 traces in the file." );
 
-    err = segy_sorting( fp, xl, il, &sorting, trace0, trace_bsize );
+    err = segy_sorting( fp, xl, il, of, &sorting, trace0, trace_bsize );
     assertTrue( err == 0, "Could not figure out file sorting." );
     assertTrue( sorting == SEGY_CROSSLINE_SORTING, "Expected crossline sorting." );
 
-    err = segy_sorting( fp, il, xl, &sorting, trace0, trace_bsize );
+    err = segy_sorting( fp, il, xl, of, &sorting, trace0, trace_bsize );
     assertTrue( err == 0, "Could not figure out file sorting." );
     assertTrue( sorting == SEGY_INLINE_SORTING, "Expected inline sorting." );
 
@@ -489,6 +490,7 @@ static void testReadInLine_4(){
 
     /* test specific consts */
     const int il = SEGY_TR_INLINE, xl = SEGY_TR_CROSSLINE;
+    const int of = SEGY_TR_OFFSET;
 
     char header[ SEGY_BINARY_HEADER_SIZE ];
 
@@ -505,7 +507,7 @@ static void testReadInLine_4(){
 
     int ok = 0;
     ok = !segy_traces( fp, &traces, trace0, trace_bsize )
-      && !segy_sorting( fp, il, xl, &sorting, trace0, trace_bsize )
+      && !segy_sorting( fp, il, xl, of, &sorting, trace0, trace_bsize )
       && !segy_offsets( fp, il, xl, traces, &offsets, trace0, trace_bsize )
       && !segy_count_lines( fp, xl, offsets, &inlines_sz, &crosslines_sz, trace0, trace_bsize )
       && !segy_inline_indices( fp, il, sorting, inlines_sz, crosslines_sz, offsets, inline_indices, trace0, trace_bsize )
@@ -564,6 +566,7 @@ static void testReadCrossLine_22(){
 
     /* test specific consts */
     const int il = SEGY_TR_INLINE, xl = SEGY_TR_CROSSLINE;
+    const int of = SEGY_TR_OFFSET;
 
     char header[ SEGY_BINARY_HEADER_SIZE ];
 
@@ -580,7 +583,7 @@ static void testReadCrossLine_22(){
 
     int ok = 0;
     ok = !segy_traces( fp, &traces, trace0, trace_bsize )
-      && !segy_sorting( fp, il, xl, &sorting, trace0, trace_bsize )
+      && !segy_sorting( fp, il, xl, of, &sorting, trace0, trace_bsize )
       && !segy_offsets( fp, il, xl, traces, &offsets, trace0, trace_bsize )
       && !segy_count_lines( fp, xl, offsets, &inlines_sz, &crosslines_sz, trace0, trace_bsize )
       && !segy_crossline_indices( fp, xl, sorting, inlines_sz, crosslines_sz, offsets, crossline_indices, trace0, trace_bsize )
@@ -815,7 +818,7 @@ static void test_file_error_codes() {
     assertTrue( err == SEGY_FSEEK_ERROR, "Could seek in invalid file." );
 
     int sorting;
-    err = segy_sorting( fp, 0, 0, &sorting, 3600, 350 );
+    err = segy_sorting( fp, 0, 0, 0, &sorting, 3600, 350 );
     assertTrue( err == SEGY_FSEEK_ERROR, "Could seek in invalid file." );
 
     err = segy_readtrace( fp, 0, NULL, 3600, 350 );

--- a/mex/segyutil.c
+++ b/mex/segyutil.c
@@ -57,7 +57,11 @@ int segyCreateSpec(SegySpec* spec, const char* file, unsigned int inline_field, 
         goto CLEANUP;
     }
 
-    errc = segy_sorting(fp, inline_field, crossline_field, &spec->trace_sorting_format, trace0, spec->trace_bsize);
+    errc = segy_sorting(fp, inline_field,
+                            crossline_field,
+                            SEGY_TR_OFFSET,
+                            &spec->trace_sorting_format,
+                            trace0, spec->trace_bsize);
     if (errc != 0) {
         goto CLEANUP;
     }

--- a/python/segyio/_segyio.c
+++ b/python/segyio/_segyio.c
@@ -720,7 +720,11 @@ static PyObject *py_init_cube_metrics(PyObject *self, PyObject *args) {
     if (PyErr_Occurred()) { return NULL; }
 
     int sorting;
-    int error = segy_sorting(p_FILE, il_field, xl_field, &sorting, trace0, trace_bsize);
+    int error = segy_sorting(p_FILE, il_field,
+                                     xl_field,
+                                     SEGY_TR_OFFSET,
+                                     &sorting,
+                                     trace0, trace_bsize);
 
     if (error != 0) {
         return py_handle_segy_error_with_fields(error, errno, il_field, xl_field, 2);


### PR DESCRIPTION
This breaks binary compatibility, so a recompilation of all downstream projects *linking* to the C lib is necessary.
 
Figuring out sorting no longer assumes that offset 37 is always the word offset, but supports any arbitrary position, with the same byte-boundary restrictions as always.

Language bindings are not updated to take this by parameter, but they're a less invasive change. I'd like to see this change merged before we reach some distributed 1.x version.