### PR TITLE
Add applications/segyio-catb

### DIFF
--- a/applications/CMakeLists.txt
+++ b/applications/CMakeLists.txt
@@ -22,7 +22,16 @@ target_compile_definitions(segyio-cath PRIVATE
     -Dsegyio_MINOR=${segyio_MINOR}
 )
 
+add_executable(segyio-catb segyio-catb.c)
+target_link_libraries(segyio-catb segyio)
+target_compile_definitions(segyio-catb PRIVATE
+    -Dsegyio_MAJOR=${segyio_MAJOR}
+    -Dsegyio_MINOR=${segyio_MINOR}
+)
 install(TARGETS segyinfo DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
 install(TARGETS segyinspect DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
 
 install(TARGETS segyio-cath DESTINATION ${CMAKE_INSTALL_BINDIR})
+install(TARGETS segyio-catb DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+add_python_test(python.segyb    test/test_segyb.py)

--- a/applications/segyio-catb.c
+++ b/applications/segyio-catb.c
@@ -1,0 +1,152 @@
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <getopt.h>
+#include <unistd.h>
+
+#include <segyio/segy.h>
+
+static int printhelp(){
+    puts( "Usage: segyio-catb [OPTION]... [FILE]...\n"
+          "Concatenate the binary header from FILE(s) to seismic unix"
+          "output.\n"
+          "\n"
+          "--version    output version information and exit\n" 
+          "--help       display this help and exit\n"
+          "\n"
+        );
+    return 0;
+}
+
+static int printversion(){
+    printf( "segyio-catb (segyio version %d.%d)\n",
+             segyio_MAJOR, segyio_MINOR );
+    return 0;
+}
+
+static int get_binary_value( char* binheader, int bfield ){
+    int32_t f;
+    segy_get_bfield( binheader, bfield, &f );
+    return f;
+}
+
+int main( int argc, char* const argv[] ){
+
+   static const char* su[ 30 ] = {
+        "jobid",
+        "lino",
+        "reno",
+        "ntrpr",
+        "nart",
+        "hdt",
+        "dto",
+        "hns",
+        "nso",
+        "format",
+        "fold",
+        "tsort",
+        "vscode",
+        "hsfs",
+        "hsfe",
+        "hslen",
+        "hstyp",
+        "schn",
+        "hstas",
+        "hstae",
+        "htatyp",
+        "hcorr",
+        "bgrcv",
+        "rcvm",
+        "mfeet",
+        "polyt",
+        "vpol",
+        "rev",
+        "trflag",
+        "exth"
+    };
+
+    static int bfield_value[ 30 ] = {
+        SEGY_BIN_JOB_ID,
+        SEGY_BIN_LINE_NUMBER,
+        SEGY_BIN_REEL_NUMBER,
+        SEGY_BIN_TRACES,
+        SEGY_BIN_AUX_TRACES,
+        SEGY_BIN_INTERVAL,
+        SEGY_BIN_INTERVAL_ORIG,
+        SEGY_BIN_SAMPLES,
+        SEGY_BIN_SAMPLES_ORIG,
+        SEGY_BIN_FORMAT,
+        SEGY_BIN_ENSEMBLE_FOLD,
+        SEGY_BIN_SORTING_CODE,
+        SEGY_BIN_VERTICAL_SUM,
+        SEGY_BIN_SWEEP_FREQ_START,
+        SEGY_BIN_SWEEP_FREQ_END,
+        SEGY_BIN_SWEEP_LENGTH,
+        SEGY_BIN_SWEEP,
+        SEGY_BIN_SWEEP_CHANNEL,
+        SEGY_BIN_SWEEP_TAPER_START,
+        SEGY_BIN_SWEEP_TAPER_END,
+        SEGY_BIN_TAPER,
+        SEGY_BIN_CORRELATED_TRACES,
+        SEGY_BIN_BIN_GAIN_RECOVERY,
+        SEGY_BIN_AMPLITUDE_RECOVERY,
+        SEGY_BIN_MEASUREMENT_SYSTEM,
+        SEGY_BIN_IMPULSE_POLARITY,
+        SEGY_BIN_VIBRATORY_POLARITY,
+        SEGY_BIN_SEGY_REVISION,
+        SEGY_BIN_TRACE_FLAG,
+        SEGY_BIN_EXT_HEADERS
+    };
+    
+    if( argc == 1 ) return printhelp();
+
+    static int version = 0;
+    
+    static struct option long_options[] = {
+        {"version",     no_argument,    &version,    1 },
+        {"help",        no_argument,    0,          'h'},
+        {0, 0, 0, 0}
+    };
+
+
+    while( true ){
+
+        int option_index = 0;
+        int c = getopt_long( argc, argv, "",
+                            long_options, &option_index);
+
+        if ( c == -1 ) break;
+
+        switch( c ){
+            case  0: break;
+            case 'h': return printhelp();
+            default:  return printhelp();
+        }
+    }
+
+    if( version ) return printversion();
+
+    for( int i = optind; i < argc; ++i ){
+        segy_file* fp = segy_open( argv[ i ], "r" );
+        if( !fp ) printf("segyio-catb: %s: No such file or directory\n",
+                           argv[ i ] );
+        if( !fp ) continue;
+
+        char binheader[ SEGY_BINARY_HEADER_SIZE ];
+        int err = segy_binheader( fp, binheader );        
+        if( err ) printf( "segyio-catb: %s: Unable to read binary header\n",
+                           argv[ i ] );
+        if( err ) continue;
+
+        for( int c = 0; c < 30; ++c ){
+            printf( "%s\t%d\n", su[ c ],
+                    get_binary_value( binheader, bfield_value[ c ] ));
+        }
+        
+        segy_close( fp );
+    }
+    return 0;
+}
+

--- a/applications/test/test_segyb.py
+++ b/applications/test/test_segyb.py
@@ -1,0 +1,76 @@
+import unittest
+import subprocess
+
+class TestSegyB(unittest.TestCase):
+
+    actual_output = [
+        b"jobid\t0",
+        b"lino\t0",
+        b"reno\t0",
+        b"ntrpr\t25",
+        b"nart\t0",
+        b"hdt\t4000",
+        b"dto\t0",
+        b"hns\t50",
+        b"nso\t0",
+        b"format\t1",
+        b"fold\t0",
+        b"tsort\t0",
+        b"vscode\t0",
+        b"hsfs\t0",
+        b"hsfe\t0",
+        b"hslen\t0",
+        b"hstyp\t0",
+        b"schn\t0",
+        b"hstas\t0",
+        b"hstae\t0",
+        b"htatyp\t0",
+        b"hcorr\t0",
+        b"bgrcv\t0",
+        b"rcvm\t0",
+        b"mfeet\t0",
+        b"polyt\t0",
+        b"vpol\t0",
+        b"rev\t0",
+        b"trflag\t0",
+        b"exth\t0"
+    ]
+    work_dir = '../../build'
+    cmd_base = './applications/segyio-catb'
+
+    def test_help(self):
+        cmd = self.cmd_base + ' --help'
+        result = subprocess.check_output(cmd, shell=True, cwd=self.work_dir)
+        self.assertEqual(result[0:18], b'Usage: segyio-catb')
+
+    def test_version(self):
+        cmd = self.cmd_base + ' --version'
+        result = subprocess.check_output(cmd, shell=True, cwd=self.work_dir)
+        self.assertEqual(result[-5:-2], b'1.2')
+
+    def test_segy_in(self):
+        filepath = self.work_dir + '/python/test-data/small.sgy'
+        cmd = self.cmd_base + ' python/test-data/small.sgy'
+        result = subprocess.check_output(cmd, shell=True, cwd=self.work_dir)
+        result_list = result.split(b'\n')
+        for i in range(len(self.actual_output)):
+            self.assertEqual(result_list[i], self.actual_output[i])
+
+    def test_non_segy_in(self):
+        cmd = self.cmd_base + ' ../applications/CMakeLists.txt'
+        result = subprocess.check_output(cmd, shell=True, cwd=self.work_dir)
+        self.assertEqual(result[-29:-1], b'Unable to read binary header')
+
+    def test_none_file(self):
+        cmd = self.cmd_base + ' nothing'
+        result = subprocess.check_output(cmd, shell=True, cwd=self.work_dir)
+        self.assertEqual(result[-26:-1], b'No such file or directory')
+
+    def test_empty_string_in(self):
+        cmd = self.cmd_base + " ";
+        result = subprocess.check_output(cmd, shell=True, cwd=self.work_dir)
+        self.assertEqual(result[0:18], b'Usage: segyio-catb')
+
+if __name__ == '__main__':
+    unittest.main()
+


### PR DESCRIPTION
Segyio-catb is a simple cat-like program that prints binary header of a SEG-Y file to stdout.
Add because it is a feature that has been expressed by the users of SegyIO  