### PR TITLE
Dont free caller buffer in read/write_subtr

### DIFF
--- a/lib/src/segy.c
+++ b/lib/src/segy.c
@@ -1234,7 +1234,7 @@ int segy_readsubtr( segy_file* fp,
 
     const size_t readc = fread( tracebuf, sizeof( float ), elems, fp->fp );
     if( readc != elems ) {
-        free( tracebuf );
+        if( !rangebuf ) free( tracebuf );
         return SEGY_FREAD_ERROR;
     }
 
@@ -1242,7 +1242,7 @@ int segy_readsubtr( segy_file* fp,
     for( ; slicelen > 0; cur += step, --slicelen, ++buf )
         *buf = *cur;
 
-    free( tracebuf );
+    if( !rangebuf ) free( tracebuf );
     return SEGY_OK;
 }
 
@@ -1309,14 +1309,17 @@ int segy_writesubtr( segy_file* fp,
     if( readc != elems ) { free( tracebuf ); return SEGY_FREAD_ERROR; }
     /* rewind, because fread advances the file pointer */
     err = fseek( fp->fp, -elemsize, SEEK_CUR );
-    if( err != 0 ) { free( tracebuf ); return SEGY_FSEEK_ERROR; }
+    if( err != 0 ) {
+        if( !rangebuf ) free( tracebuf );
+        return SEGY_FSEEK_ERROR;
+    }
 
     float* cur = tracebuf + defstart;
     for( ; slicelen > 0; cur += step, --slicelen, ++buf )
         *cur = *buf;
 
     const size_t writec = fwrite( tracebuf, sizeof( float ), elems, fp->fp );
-    free( tracebuf );
+    if( !rangebuf ) free( tracebuf );
 
     if( writec != elems ) return SEGY_FWRITE_ERROR;
 

--- a/lib/test/segy.c
+++ b/lib/test/segy.c
@@ -115,12 +115,13 @@ static void test_read_subtr( bool mmap ) {
 
     const int format = SEGY_IBM_FLOAT_4_BYTE;
     int trace0 = 3600;
-    int trace_bsize = 50 * 4;
+    int trace_bsize = 50 * sizeof( float );
     int err = 0;
 
     if( mmap ) segy_mmap( fp );
 
     float buf[ 5 ];
+    float rangebuf[ 50 ];
     /* read a strided chunk across the middle of all traces */
     /* should read samples 3, 8, 13, 18 */
     err = segy_readsubtr( fp,
@@ -129,7 +130,7 @@ static void test_read_subtr( bool mmap ) {
                           19,       /* stop */
                           5,        /* step */
                           buf,
-                          NULL,
+                          rangebuf, // readsubtr shouldn't try to free this
                           trace0,
                           trace_bsize );
     assertTrue( err == 0, "Unable to correctly read subtrace" );
@@ -195,7 +196,7 @@ static void test_write_subtr( bool mmap ) {
     const char *file = "test-data/write-subtr.sgy";
     segy_file* fp = segy_open( file, "w+b" );
     int trace0 = 3600;
-    int trace_bsize = 50 * 4;
+    int trace_bsize = 50 * sizeof( float );
     int err = 0;
 
     const int format = SEGY_IBM_FLOAT_4_BYTE;
@@ -208,6 +209,7 @@ static void test_write_subtr( bool mmap ) {
     assertTrue( err == 0, "Error in write-subtr setup." );
 
     float buf[ 5 ];
+    float rangebuf[ 50 ];
     float out[ 5 ] = { 2.0, 2.1, 2.2, 2.3, 2.4 };
     segy_from_native( format, 5, out );
 
@@ -219,7 +221,7 @@ static void test_write_subtr( bool mmap ) {
                            19,       /* stop */
                            5,        /* step */
                            out,
-                           NULL,
+                           rangebuf, // writesubtr shouldn't try to free this
                            trace0,
                            trace_bsize );
     assertTrue( err == 0, "Unable to correctly write subtrace" );


### PR DESCRIPTION
The read/write subtr functions can take a buffer for when the function
is to be called repeatedly for speed purposes, but will allocate
otherwise. However, the functions always tried to free this buffer, even
if it wasn't allocated by the function.

Check if the buffer was actually allocated by the functions before
attempting to free.

Tests are updated to check for this.