### PR TITLE
Remove hard-coded folder name from tests

### DIFF
--- a/applications/test/catb.py
+++ b/applications/test/catb.py
@@ -36,7 +36,7 @@ class TestSegyB(unittest.TestCase):
         b"trflag\t0",
         b"exth\t0"
     ]
-    work_dir = '../../build'
+    work_dir = '../'
     cmd_base = './applications/segyio-catb'
     FNULL = open(os.devnull, 'w')
 

--- a/applications/test/cath.py
+++ b/applications/test/cath.py
@@ -20,7 +20,7 @@ class TestSegyH(unittest.TestCase):
         b"C14",
         b"C15 END EBCDIC HEADER",
     ]
-    work_dir = '../../build'
+    work_dir = '../'
     cmd_base = './applications/segyio-cath'
     FNULL = open(os.devnull, 'w')
 


### PR DESCRIPTION
The tests assumed that the build folder was called `build` and that it was inside the source folder, but this is not necessarily the case.

Since ctest is normally executed from the build folder, `../` should be correct

(Honestly I don't know if this breaks anything else, the tests pass on my machine)

