### PR TITLE
Implement segy_ftell with ftello

### DIFF
--- a/cmake/check_includes.cmake
+++ b/cmake/check_includes.cmake
@@ -38,3 +38,8 @@ if (HAVE_SYS_STAT_H)
         add_definitions("-DHAVE_FTELLI64")
     endif ()
 endif()
+
+check_function_exists(ftello HAVE_FTELLO)
+if (HAVE_FTELLO)
+    add_definitions("-DHAVE_FTELLO")
+endif ()

--- a/lib/src/segy.c
+++ b/lib/src/segy.c
@@ -1,5 +1,9 @@
 #define _POSIX_SOURCE /* fileno */
 
+/* 64-bit off_t in ftello */
+#define _POSIX_C_SOURCE 200808L
+#define _FILE_OFFSET_BITS 64
+
 #ifdef HAVE_MMAP
   #define _POSIX_SOURCE
   #include <sys/mman.h>
@@ -400,14 +404,16 @@ int segy_flush( segy_file* fp, bool async ) {
 }
 
 long long segy_ftell( segy_file* fp ) {
-#ifdef HAVE_FTELLI64
+#ifdef HAVE_FTELLO
+    off_t pos = ftello( fp->fp );
+    assert( pos != -1 );
+    return pos;
+#elif HAVE_FTELLI64
     // assuming we're on windows. This function is a little rough, but only
     // meant for testing - it's not a part of the public interface.
     return _ftelli64( fp->fp );
 #else
-    // cppcheck-suppress duplicateExpression
-    assert( sizeof( long ) == sizeof( long long ) );
-    return ftell( fp->fp );
+    assert( false );
 #endif
 }
 

--- a/lib/test/segy.c
+++ b/lib/test/segy.c
@@ -878,6 +878,7 @@ static void test_file_size_above_4GB(){
     long long pos = segy_ftell( fp );
     assertTrue(pos > (long long)INT_MAX, "pos smaller than INT_MAX. "
                               "This means there's an overflow somewhere" );
+    assertTrue(pos != -1, "overflow in off_t");
     assertTrue(pos == trace * tracesize, "seek overflow");
     segy_close(fp);
 }


### PR DESCRIPTION
Change the ftell implementation to use the ftello posix function ftello,
enabling 64-bit files on all systems, in partiuclar when long is a
32-bit and regular ftell won't work.

The order of the fstat/ftell macros are changed, preferring
non-underscore prefix'd function when available.