### PR TITLE
[minor] Make print statements in README Python3 compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,15 +160,15 @@ with segyio.open(filename, "r" ) as segyfile:
     segyfile.mmap()
 
     # Print binary header info
-    print segyfile.bin
-    print segyfile.bin[segyio.BinField.Traces]
+    print(segyfile.bin)
+    print(segyfile.bin[segyio.BinField.Traces])
 
     # Read headerword inline for trace 10
-    print segyfile.header[10][segyio.TraceField.INLINE_3D]
+    print(segyfile.header[10][segyio.TraceField.INLINE_3D])
 
     # Print inline and crossline axis
-    print segyfile.xlines
-    print segyfile.ilines
+    print(segyfile.xlines)
+    print(segyfile.ilines)
 ```
 
 Read post-stack data cube contained in segy file:
@@ -194,7 +194,7 @@ filename='name_of_your_prestack_file.sgy'
 with segyio.open( filename, "r" ) as segyfile:
 
     # Print offsets
-    print segyfile.offset
+    print(segyfile.offset)
 
     # Read data along first iline and offset 100:  data [nxl x nt]
     data=segyfile.iline[0,100]


### PR DESCRIPTION
Change `print x` to `print(x)` in the README.