### PR TITLE
Add tag to filename in c.segy.mmap test

### DIFF
--- a/cppcheck/suppressions.txt
+++ b/cppcheck/suppressions.txt
@@ -10,3 +10,7 @@ resourceLeak:*segyio-crop.c
 
 // Ignore all warnings for external libraries
 *:*external/*
+
+// Singe argument no-explicit constructor is used purposefully to construct
+// objects from integer error codes for generating test output
+noExplicitConstructor:*test/*.cpp

--- a/lib/test/segy.cpp
+++ b/lib/test/segy.cpp
@@ -609,7 +609,7 @@ SCENARIO( MMAP_TAG "modifying trace header", "[c.segy]" MMAP_TAG ) {
             CHECK( scale == -100 );
         }
 
-        const char* file = "write-traceheader.sgy";
+        const char* file = MMAP_TAG "write-traceheader.sgy";
 
         std::unique_ptr< segy_file, decltype( &segy_close ) >
             ufp{ segy_open( file, "w+b" ), &segy_close };

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -130,5 +130,5 @@ add_test(NAME python.example.write        COMMAND ${python} write.py test-data/w
 add_test(NAME python.example.makefile     COMMAND ${python} make-file.py test-data/large-file.sgy 20 1 20 1 20)
 add_test(NAME python.example.makepsfile   COMMAND ${python} make-ps-file.py test-data/small-prestack.sgy 10 1 5 1 4 1 3)
 add_test(NAME python.example.subcube      COMMAND ${python} copy-sub-cube.py test-data/small.sgy test-data/copy.sgy)
-add_test(NAME python.example.rotate       COMMAND ${python} make-rotated-copies.py test-data/small.sgy)
+add_test(NAME python.example.rotate       COMMAND ${python} make-rotated-copies.py test-data/small.sgy ex-rotate.sgy)
 add_test(NAME python.example.scan_min_max COMMAND ${python} scan_min_max.py test-data/small.sgy)


### PR DESCRIPTION
c.segy.mmap and c.segy tests were creating file using the same filename.
This may cause errors when running these tests simultaneously.