### PR TITLE
Only write last trace in 16bit overflow test

### DIFF
--- a/python/test/segy.py
+++ b/python/test/segy.py
@@ -1080,10 +1080,9 @@ def test_no_16bit_overflow_tracecount(tmpdir):
     with segyio.create(tmpdir / 'foo.sgy', spec) as f:
         assert f.tracecount > 0
         assert f.tracecount > 2**16 - 1
-        for i in range(f.tracecount):
-            f.trace[i] = ones
-            f.header[i] = {
-                    segyio.TraceField.INLINE_3D: i,
-                    segyio.TraceField.CROSSLINE_3D: i,
+        f.trace[-1] = ones
+        f.header[-1] = {
+                    segyio.TraceField.INLINE_3D: 10,
+                    segyio.TraceField.CROSSLINE_3D: 10,
                     segyio.TraceField.offset: 1,
-            }
+        }


### PR DESCRIPTION
Only write the final trace+header in the 16-bit overflow python test.
This still covers the overflow case, but doesn't use the disk as much.

Closes https://github.com/Statoil/segyio/issues/240