### PR TITLE
Add glibc.i686 to config.sh

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -18,6 +18,10 @@ function pre_build {
 
     mkdir build-centos5
     pushd build-centos5
+
+    # the cmake binary is compiled for 686, and the centos5 docker image does
+    # not provide libc.i686 by default
+    yum install -y glibc.i686
     export cmake=cmake-2.8.12.2-Linux-i386
     wget --no-check-certificate https://cmake.org/files/v2.8/cmake-2.8.12.2-Linux-i386.tar.gz
     tar xzvf $cmake.tar.gz


### PR DESCRIPTION
Previously, the i686 libc was available in the pypa manylinux image. It
seems that the commit 4c1c549 changed this upstream, which means our
config.sh needs upgrading.

[1] https://github.com/pypa/manylinux/commit/4c1c5496d86d85875126ac807d15c42fc2289a77