### PR TITLE
Install pytest-runner on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,7 @@ install:
         brew update && brew install cppcheck;
     fi
   - pip install -r requirements.txt
-  - pip install bandit setuptools setuptools-scm pytest
+  - pip install bandit setuptools setuptools-scm pytest pytest-runner
 
 before_script:
   - enabled="-DBUILD_PYTHON=OFF -DBUILD_MEX=OFF"


### PR DESCRIPTION
Pip is usually able to resolve, download, and use the pytest runner
dependency, but fails a lot on OS X, seemingly because of distutils
challenges. By installing it explicitly with the approperiate pip this
problem goes away.