### PR TITLE
Fall back to git-describe for version in conf.py

### DIFF
--- a/python/docs/conf.py
+++ b/python/docs/conf.py
@@ -74,6 +74,22 @@ import segyio
 #
 # The short X.Y version.
 version = segyio.__version__
+
+# if the docs are built without actually building segyio (what readthedocs
+# does), the version string will fall back to '0.0.0'. but since readthedocs
+# (and maybe other jobs that builds doc) often fetch from git, they can fall
+# back to also trying git-describe themselves.
+if version == '0.0.0':
+    try:
+        # static analysis flags the subproces module as a potential security
+        # problem, but this takes no user input and should be safe
+        from subprocess import check_output # nosec
+        version = str(check_output(['git', 'describe']).strip()) # nosec
+    finally:
+        # couldn't run git-describe - fall back to 0.0.0 and accept that we
+        # won't get reasonable version numbers automatically
+        pass
+
 # The full version, including alpha/beta/rc tags.
 release = version
 


### PR DESCRIPTION
The `segyio.__version__` string is only properly set if
    1. it's built with make and/or setuptools
    2. a version.py file exists (distributed with the tarballs)

Neither of these are the case for readthedocs.io and other standalone
sphinx doc builds. Since they mostly fetch with git anyway, it's a
convenient fallback for better document versioning than every revision
being `0.0.0`