### PR TITLE
Use fixture + test-case for set-format test

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -8,6 +8,7 @@ function run_tests {
 
 
 function pre_build {
+    set -e
     if [ -n "$IS_OSX" ]; then return; fi
     if [ -d build-centos5 ]; then return; fi
 

--- a/config.sh
+++ b/config.sh
@@ -24,7 +24,7 @@ function pre_build {
     # not provide libc.i686 by default
     yum install -y glibc.i686
     export cmake=cmake-2.8.12.2-Linux-i386
-    wget --no-check-certificate https://cmake.org/files/v2.8/cmake-2.8.12.2-Linux-i386.tar.gz
+    curl -o $cmake.tar.gz https://cmake.org/files/v2.8/cmake-2.8.12.2-Linux-i386.tar.gz
     tar xzvf $cmake.tar.gz
     ./$cmake/bin/cmake --version
     ./$cmake/bin/cmake .. -DBUILD_PYTHON=OFF -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON

--- a/cppcheck/suppressions.txt
+++ b/cppcheck/suppressions.txt
@@ -7,3 +7,7 @@ preprocessorErrorDirective:*Python.h
 // cppcheck struggles with the expression templates of catch, giving this error
 // for long == long comparisons
 compareBoolExpressionWithInt:*lib/test/segy.cpp
+
+// cppcheck gets very confused by fixtures, claiming members are unused,
+// so just ignore that warning
+unusedStructMember:*lib/test/segy.cpp

--- a/lib/test/mmap.cpp
+++ b/lib/test/mmap.cpp
@@ -1,6 +1,6 @@
 #ifdef HAVE_MMAP
 
-#define MMAP_TAG "[mmap]"
+#define MMAP_TAG "[mmap] "
 #include "segy.cpp"
 
 #endif //HAVE_MMAP

--- a/lib/test/segy.cpp
+++ b/lib/test/segy.cpp
@@ -816,47 +816,6 @@ TEST_CASE_METHOD( smallcube,
     CHECK_THAT( line, ApproxRange( expected ) );
 }
 
-SCENARIO( MMAP_TAG "reading a file", "[c.segy]" MMAP_TAG ) {
-    const char* file = "test-data/small.sgy";
-
-    std::unique_ptr< segy_file, decltype( &segy_close ) >
-        ufp{ segy_open( file, "rb" ), &segy_close };
-
-    REQUIRE( ufp );
-
-    auto fp = ufp.get();
-    if( MMAP_TAG != std::string("") )
-        REQUIRE( Err( segy_mmap( fp ) ) == Err::ok() );
-
-    const long trace0 = 3600;
-    const int trace_bsize = 50 * 4;
-    const int samples = 50;
-
-    const int traces = 25;
-    const int inlines_sizes = 5;
-    const int crosslines_sizes = 5;
-    const int offset_label = 1;
-
-    regular_geometry( fp, traces,
-                          trace0,
-                          trace_bsize,
-                          inlines_sizes,
-                          crosslines_sizes,
-                          offset_label );
-
-    const int il = SEGY_TR_INLINE;
-    const int xl = SEGY_TR_CROSSLINE;
-    const int of = SEGY_TR_OFFSET;
-    const int sorting = SEGY_INLINE_SORTING;
-    const int offsets = 1;
-    const int format = SEGY_IBM_FLOAT_4_BYTE;
-
-    const std::vector< int > inlines = { 1, 2, 3, 4, 5 };
-    const std::vector< int > crosslines = { 20, 21, 22, 23, 24 };
-    const int inline_length = 5;
-    const int crossline_length = 5;
-}
-
 SCENARIO( MMAP_TAG "writing to a file", "[c.segy]" MMAP_TAG ) {
     const long trace0 = 3600;
     const int trace_bsize = 50 * 4;

--- a/lib/test/segy.cpp
+++ b/lib/test/segy.cpp
@@ -210,6 +210,13 @@ struct smallsize : smallfields {
     int traces = 25;
 };
 
+struct smallshape : smallsize {
+    int offsets = 1;
+    int ilines = 5;
+    int xlines = 5;
+    int sorting = SEGY_INLINE_SORTING;
+};
+
 bool success( Err err ) {
     return err == Err::ok();
 }
@@ -340,6 +347,48 @@ TEST_CASE_METHOD( smallsize,
 
     CHECK( success( err ) );
     CHECK( offsets == 1 );
+}
+
+TEST_CASE_METHOD( smallshape,
+                  MMAP_TAG "correct # of lines are detected",
+                  MMAP_TAG "[c.segy]" ) {
+
+    int expected_ils = 5;
+    int expected_xls = 5;
+
+    int count_inlines;
+    int count_crosslines;
+    Err err_count = segy_count_lines( fp,
+                                      xl,
+                                      offsets,
+                                      &count_inlines,
+                                      &count_crosslines,
+                                      trace0,
+                                      trace_bsize );
+
+    int lines_inlines;
+    int lines_crosslines;
+    Err err_lines = segy_lines_count( fp,
+                                      il,
+                                      xl,
+                                      sorting,
+                                      offsets,
+                                      &lines_inlines,
+                                      &lines_crosslines,
+                                      trace0,
+                                      trace_bsize );
+
+    CHECK( success( err_count ) );
+    CHECK( success( err_lines ) );
+
+    CHECK( count_inlines    == expected_ils );
+    CHECK( count_crosslines == expected_xls );
+
+    CHECK( lines_inlines    == expected_ils );
+    CHECK( lines_crosslines == expected_xls );
+
+    CHECK( lines_inlines    == count_inlines );
+    CHECK( lines_crosslines == count_crosslines );
 }
 
 SCENARIO( MMAP_TAG "reading a file", "[c.segy]" MMAP_TAG ) {

--- a/lib/test/segy.cpp
+++ b/lib/test/segy.cpp
@@ -211,6 +211,26 @@ struct smallfix {
     }
 };
 
+struct smallbin : smallfix {
+    char bin[ SEGY_BINARY_HEADER_SIZE ];
+
+    smallbin() : smallfix() {
+        REQUIRE( Err( segy_binheader( fp, bin ) ) == Err::ok() );
+    }
+};
+
+}
+
+TEST_CASE_METHOD( smallbin,
+                  MMAP_TAG "samples+positions from binary header are correct",
+                  MMAP_TAG "[c.segy]" ) {
+    int samples = segy_samples( bin );
+    long trace0 = segy_trace0( bin );
+    int trace_bsize = segy_trsize( SEGY_IBM_FLOAT_4_BYTE, samples );
+
+    CHECK( trace0      == 3600 );
+    CHECK( samples     == 50 );
+    CHECK( trace_bsize == 50 * 4 );
 }
 
 TEST_CASE_METHOD( smallfix,
@@ -238,18 +258,6 @@ SCENARIO( MMAP_TAG "reading a file", "[c.segy]" MMAP_TAG ) {
     auto fp = ufp.get();
     if( MMAP_TAG != std::string("") )
         REQUIRE( Err( segy_mmap( fp ) ) == Err::ok() );
-
-    WHEN( "finding traces initial byte offset and sizes" ) {
-        char header[ SEGY_BINARY_HEADER_SIZE ];
-        REQUIRE( Err( segy_binheader( fp, header ) ) == Err::ok() );
-        int samples = segy_samples( header );
-        long trace0 = segy_trace0( header );
-        int trace_bsize = segy_trsize( SEGY_IBM_FLOAT_4_BYTE, samples );
-
-        CHECK( trace0      == 3600 );
-        CHECK( samples     == 50 );
-        CHECK( trace_bsize == 50 * 4 );
-    }
 
     const long trace0 = 3600;
     const int trace_bsize = 50 * 4;

--- a/lib/test/segy.cpp
+++ b/lib/test/segy.cpp
@@ -206,6 +206,10 @@ struct smallfields : smallbasic {
     int of = SEGY_TR_OFFSET;
 };
 
+struct smallsize : smallfields {
+    int traces = 25;
+};
+
 bool success( Err err ) {
     return err == Err::ok();
 }
@@ -304,6 +308,38 @@ TEST_CASE_METHOD( smallfields,
     Err err = segy_sorting( fp, xl, il, of, &sorting, trace0, trace_bsize );
     CHECK( success( err ) );
     CHECK( sorting == SEGY_CROSSLINE_SORTING );
+}
+
+TEST_CASE_METHOD( smallsize,
+                  MMAP_TAG "post-stack file offset-count is 1",
+                  MMAP_TAG "[c.segy]" ) {
+    int offsets;
+    Err err = segy_offsets( fp,
+                            il,
+                            xl,
+                            traces,
+                            &offsets,
+                            trace0,
+                            trace_bsize );
+
+    CHECK( success( err ) );
+    CHECK( offsets == 1 );
+}
+
+TEST_CASE_METHOD( smallsize,
+                  MMAP_TAG "swapped il/xl post-stack file offset-count is 1",
+                  MMAP_TAG "[c.segy]" ) {
+    int offsets;
+    Err err = segy_offsets( fp,
+                            xl,
+                            il,
+                            traces,
+                            &offsets,
+                            trace0,
+                            trace_bsize );
+
+    CHECK( success( err ) );
+    CHECK( offsets == 1 );
 }
 
 SCENARIO( MMAP_TAG "reading a file", "[c.segy]" MMAP_TAG ) {

--- a/lib/test/segy.cpp
+++ b/lib/test/segy.cpp
@@ -220,8 +220,8 @@ struct smallbin : smallfix {
 };
 
 struct smallbasic : smallfix {
-    static const long trace0 = 3600;
-    static const int trace_bsize = 50 * 4;
+    long trace0 = 3600;
+    int trace_bsize = 50 * 4;
 };
 
 bool success( Err err ) {
@@ -292,6 +292,17 @@ TEST_CASE_METHOD( smallbasic,
     int traces = input_traces;
     Err err = segy_traces( fp, &traces, -1, trace_bsize );
     CHECK( err == Err::args() );
+    CHECK( traces == input_traces );
+}
+
+TEST_CASE_METHOD( smallbasic,
+                  MMAP_TAG "erroneous trace_bsize is detected",
+                  MMAP_TAG "[c.segy]" ) {
+    const int input_traces = arbitrary_int();
+    int traces = input_traces;
+    const int too_long_bsize = trace_bsize + sizeof( float );
+    Err err = segy_traces( fp, &traces, trace0, too_long_bsize );
+    CHECK( err == SEGY_TRACE_SIZE_MISMATCH );
     CHECK( traces == input_traces );
 }
 


### PR DESCRIPTION
Move from the BDD-section to TEST_CASE_METHOD. The goal is to make the
actual test shorter and more to the point, at the cost of slightly more
convoluted dependency chain.