### PR TITLE
Check that offset field is valid in sorting

### DIFF
--- a/lib/src/segy.c
+++ b/lib/src/segy.c
@@ -997,15 +997,18 @@ int segy_sorting( segy_file* fp,
     err = segy_traceheader( fp, 0, traceheader, trace0, trace_bsize );
     if( err != SEGY_OK ) return err;
 
-    if( il < 0 || il >= SEGY_TRACE_HEADER_SIZE )
-        return SEGY_INVALID_FIELD;
-
-    if( xl < 0 || xl >= SEGY_TRACE_HEADER_SIZE )
-        return SEGY_INVALID_FIELD;
-
     /* make sure field is valid, so we don't have to check errors later */
-    if( field_size[ il ] == 0 || field_size[ xl ] == 0 )
-        return SEGY_INVALID_FIELD;
+    const int fields[] = { il, xl, tr_offset };
+    int len = sizeof( fields ) / sizeof( int );
+    for( int i = 0; i < len; ++i ) {
+        const int f = fields[ i ];
+        if( f < 0 )
+            return SEGY_INVALID_FIELD;
+        if( f >= SEGY_TRACE_HEADER_SIZE )
+            return SEGY_INVALID_FIELD;
+        if( field_size[ f ] == 0 )
+            return SEGY_INVALID_FIELD;
+    }
 
     int il0 = 0, xl0 = 0, il1 = 0, xl1 = 0, off0 = 0, off1 = 0;
 

--- a/lib/test/segy.cpp
+++ b/lib/test/segy.cpp
@@ -393,6 +393,20 @@ TEST_CASE_METHOD( smallfields,
     CHECK( sorting == SEGY_CROSSLINE_SORTING );
 }
 
+TEST_CASE_METHOD( smallfields,
+                  MMAP_TAG "invalid in-between byte offsets are detected",
+                  MMAP_TAG "[c.segy]" ) {
+    int sorting;
+    Err err = segy_sorting( fp, il + 1, xl, of, &sorting, trace0, trace_bsize );
+    CHECK( err == SEGY_INVALID_FIELD );
+
+    err = segy_sorting( fp, il, xl + 1, of, &sorting, trace0, trace_bsize );
+    CHECK( err == SEGY_INVALID_FIELD );
+
+    err = segy_sorting( fp, il, xl, of + 1, &sorting, trace0, trace_bsize );
+    CHECK( err == SEGY_INVALID_FIELD );
+}
+
 TEST_CASE_METHOD( smallsize,
                   MMAP_TAG "post-stack file offset-count is 1",
                   MMAP_TAG "[c.segy]" ) {


### PR DESCRIPTION
The in- and crossline fields were checked for validity, but offsets were
happily ignored. This didn't have a proper test case, and slipped
through.