### PR TITLE
Fix an issue where segyio-catr printed the same trace twice

### DIFF
--- a/applications/CMakeLists.txt
+++ b/applications/CMakeLists.txt
@@ -63,7 +63,8 @@ endif ()
 
 set(small ${testdata}/small.sgy)
 set(test ${CMAKE_CURRENT_SOURCE_DIR}/test)
-add_test(NAME catr.arg.t        COMMAND segyio-catr -t 5 ${small})
+add_test(NAME catr.arg.t1       COMMAND segyio-catr -t 0 ${small})
+add_test(NAME catr.arg.t2       COMMAND segyio-catr -t 5 ${small})
 add_test(NAME catr.arg.r1       COMMAND segyio-catr -r 5 ${small})
 add_test(NAME catr.arg.r2       COMMAND segyio-catr -r 1 2 ${small})
 add_test(NAME catr.arg.r3       COMMAND segyio-catr -r 1 2 3 ${small} -r 5 6)
@@ -81,7 +82,8 @@ add_test(NAME cath.fail.nosegy  COMMAND segyio-cath ${test}/cath.output)
 add_test(NAME cath.fail.nofile  COMMAND segyio-cath --strict not-exist)
 add_test(NAME cath.fail.noarg   COMMAND segyio-cath)
 
-set_tests_properties(catb.fail.nosegy
+set_tests_properties(catr.arg.t1
+                     catb.fail.nosegy
                      catb.fail.nofile
                      catb.fail.noarg
                      cath.fail.nosegy

--- a/applications/segyio-catr.c
+++ b/applications/segyio-catr.c
@@ -429,6 +429,11 @@ static struct options parse_options( int argc, char** argv ){
                         return opts;
                     }
 
+                    if( r->start == 0 )
+                        exit( errmsg( -3, "out of range" ) );
+
+                    r->stop = r->start;
+
                     goto done;
                 }
 
@@ -439,6 +444,9 @@ static struct options parse_options( int argc, char** argv ){
                     opts.errmsg = "range parameters must be positive";
                     return opts;
                }
+
+               if( r->start == 0 )
+                   exit( errmsg( -3, "out of range" ) );
 
                // if sscanf found something it consumes 1 argument, and we
                // won't have to rewind optind
@@ -500,6 +508,7 @@ int main( int argc, char** argv ) {
 
     /* verify all ranges are sane */
     for( range* r = opts.r; r < opts.r + opts.rsize; ++r ) {
+        if( r->stop == 0 && r->step == 0 ) continue;
         if( r->start > r->stop && strict )
             exit( errmsg( -3, "Range is empty" ) );
     }

--- a/man/segyio-catr.1
+++ b/man/segyio-catr.1
@@ -12,7 +12,8 @@ Print selected traceheaders from SEG-Y file FILE
 .PP
 
 The flag \fB--range\fR takes up to three vales; START, STOP, STEP, which is a closed inteval from START to STOP.
-The third value STEP can be specified to print i.e. every other trace in the interval. All values are defaulted to zero.
+The third value STEP can be specified to print i.e. every other trace in the interval. All values are defaulted to 1.
+Traces are 1-indexed.
 
 Flags \fB-r\fR and \fB-t\fR can be called multiple times.
 


### PR DESCRIPTION
While segycatr takes range arguments as 1-indexed, it would still
print the first trace if 0 was given as --range or --trace. Hence, situasions
where the first trace was printed twice could occur. Now, zero is no longer
accepted as a vaule for --range or --trace. This behavior is added to man-page