### PR TITLE
Files with fields (il, xl, offset) = (0,0,0) are set to unsorted

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -53,6 +53,8 @@ if (NOT BUILD_TESTING)
 endif ()
 
 configure_file(${testdata}/small.sgy test-data/small.sgy             COPYONLY)
+configure_file(${testdata}/1x1.sgy   test-data/1x1.sgy               COPYONLY)
+configure_file(${testdata}/1xN.sgy   test-data/1xN.sgy               COPYONLY)
 configure_file(${testdata}/f3.sgy    test-data/f3.sgy                COPYONLY)
 configure_file(${testdata}/text.sgy  test-data/text.sgy              COPYONLY)
 

--- a/lib/test/segy.cpp
+++ b/lib/test/segy.cpp
@@ -1461,3 +1461,103 @@ SCENARIO( MMAP_TAG "reading a 2-byte int file", "[c.segy][2-byte]" MMAP_TAG ) {
         }
     }
 }
+
+SCENARIO( MMAP_TAG "checking sorting for wonky files",
+                   "[c.segy]" MMAP_TAG ) {
+    WHEN( "checking sorting when il, xl and offset is all garbage ") {
+        /*
+         * In the case where all tracefields ( il, xl, offset ) = ( 0, 0, 0 )
+         * the sorting detection should return 'SEGY_INVALID_SORTING'. To test
+         * this the traceheader field 'SEGY_TR_SEQ_LINE', which we know is zero
+         * in all traceheaders in file small.sgy, is passed to segy_sorting as
+         * il, xl and offset.
+         */
+        const char* file = "test-data/small.sgy";
+
+        std::unique_ptr< segy_file, decltype( &segy_close ) >
+            ufp{ segy_open( file, "rb" ), &segy_close };
+
+        REQUIRE( ufp );
+        auto fp = ufp.get();
+
+        char header[ SEGY_BINARY_HEADER_SIZE ];
+        REQUIRE( Err( segy_binheader( fp, header ) ) == Err::ok() );
+
+        long trace0 = segy_trace0( header );
+        int samples = segy_samples( header );
+        int format = segy_format( header );
+        int trace_bsize = segy_trsize( format, samples );
+
+        int sorting;
+            int err = segy_sorting( fp,
+                                    SEGY_TR_SEQ_LINE,
+                                    SEGY_TR_SEQ_LINE,
+                                    SEGY_TR_SEQ_LINE,
+                                    &sorting,
+                                    trace0,
+                                    trace_bsize );
+
+        CHECK( err == SEGY_OK );
+        CHECK( sorting == SEGY_UNKNOWN_SORTING );
+    }
+
+    WHEN( "checking sorting when file have dimentions 1x1 ") {
+        const char* file = "test-data/1x1.sgy";
+
+        std::unique_ptr< segy_file, decltype( &segy_close ) >
+            ufp{ segy_open( file, "rb" ), &segy_close };
+
+        REQUIRE( ufp );
+        auto fp = ufp.get();
+
+        char header[ SEGY_BINARY_HEADER_SIZE ];
+        REQUIRE( Err( segy_binheader( fp, header ) ) == Err::ok() );
+
+        long trace0 = segy_trace0( header );
+        int samples = segy_samples( header );
+        int format = segy_format( header );
+        int trace_bsize = segy_trsize( format, samples );
+
+        int sorting;
+        int err = segy_sorting( fp,
+                                SEGY_TR_INLINE,
+                                SEGY_TR_CROSSLINE,
+                                SEGY_TR_OFFSET,
+                                &sorting,
+                                trace0,
+                                trace_bsize );
+
+        CHECK( err == SEGY_OK );
+        CHECK( sorting == SEGY_CROSSLINE_SORTING );
+    }
+
+    WHEN( "checking sorting when file have dimentions 1xN ") {
+        const char* file = "test-data/1xN.sgy";
+
+        std::unique_ptr< segy_file, decltype( &segy_close ) >
+            ufp{ segy_open( file, "rb" ), &segy_close };
+
+        REQUIRE( ufp );
+        auto fp = ufp.get();
+
+        char header[ SEGY_BINARY_HEADER_SIZE ];
+        REQUIRE( Err( segy_binheader( fp, header ) ) == Err::ok() );
+
+        long trace0 = segy_trace0( header );
+        int samples = segy_samples( header );
+        int format = segy_format( header );
+        int trace_bsize = segy_trsize( format, samples );
+
+        int sorting;
+        int err = segy_sorting( fp,
+                                SEGY_TR_INLINE,
+                                SEGY_TR_CROSSLINE,
+                                SEGY_TR_OFFSET,
+                                &sorting,
+                                trace0,
+                                trace_bsize );
+
+        CHECK( err == SEGY_OK );
+        CHECK( sorting == SEGY_INLINE_SORTING );
+    }
+}

--- a/python/test/segy.py
+++ b/python/test/segy.py
@@ -1202,7 +1202,7 @@ def test_create_from_naught_unstructured(tmpdir):
         # Set header field 'offset' to 1 in all headers
         dst.header = {TraceField.offset: 1}
 
-    with segyio.open(tmpdir / "unstructured.sgy") as f:
+    with segyio.open(tmpdir / "unstructured.sgy", ignore_geometry=True) as f:
         assert 1 == approx(f.trace[1][0], abs=1e-4)
         assert 2 == approx(f.trace[1][1], abs=1e-4)
         assert 150 == approx(f.trace[1][-1], abs=1e-4)


### PR DESCRIPTION
In reference to issue #274, segy_sorting now check offsets as well as il and xl when determining sorting. Additional tests are added to check the sorting for wonky files. 

This PR also include a modification to a python test where an unstructed file is created and then opened. This file would previously be categorized as sorted, and thus the test would succeed in opening the file in strict mode. The test will now try to open the file with ignore_geometry=True.  