### PR TITLE
Build segyio target shared/static from config

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -52,7 +52,12 @@ build_script:
     - IF "%platform%" == "x64" set W64="-GVisual Studio 14 2015 Win64"
     - mkdir build
     - ps: pushd build
-    - cmake %APPVEYOR_BUILD_FOLDER% %W64% %MEX% %LANG% -DCMAKE_INSTALL_PREFIX=%INSTALL_DIR%
+    - cmake %APPVEYOR_BUILD_FOLDER%
+            %W64%
+            %MEX%
+            %LANG%
+            -DCMAKE_INSTALL_PREFIX=%INSTALL_DIR%
+            -DBUILD_SHARED_LIBS=ON
     - cmake --build . --config "%configuration%" --target install
     - ctest -C "%configuration%" --output-on-failure
     - ps: popd

--- a/external/catch2/CMakeLists.txt
+++ b/external/catch2/CMakeLists.txt
@@ -3,5 +3,10 @@ project(catch2 CXX)
 
 # Dummy source file added because INTERFACE type
 # library is not available in CMake 2.8.12
-add_library(catch2 dummy.cpp)
+# it's STATIC, because MSVC would otherwise not generate a .lib file, making
+# "linking" (for header path) fail later
+#
+# TODO: when cmake minimum version is bumped to 3.x series, replace with
+# an INTERFACE library
+add_library(catch2 STATIC dummy.cpp)
 target_include_directories(catch2 SYSTEM PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,76 +1,52 @@
 project(libsegyio C)
 
-set(SOURCE_FILES src/segy.c)
-
-set(STATIC_NAME segyio)
 if(MSVC)
-    # MSVC outputs the same name for static and shared libraries (with the same
-    # extension), so we need to differentiate between the two somehow.
-    set(STATIC_NAME "${STATIC_NAME}-static")
     set(DLL_EXPORT_FILES src/segy.def)
 endif()
 
-#
-# static build
-#
-add_library(segyio-static STATIC ${SOURCE_FILES})
-target_link_libraries(segyio-static ${m} ${ws2})
-target_compile_definitions(segyio-static PRIVATE
-    ${htons} ${mmap} ${fstat} ${ftello})
-target_compile_options(segyio-static BEFORE
-    PRIVATE $<$<CONFIG:Debug>:${warnings-c}> ${c99}
+add_library(segyio src/segy.c ${DLL_EXPORT_FILES})
+target_link_libraries(segyio ${m} ${ws2})
+target_compile_options(segyio BEFORE
+    PRIVATE
+        ${c99}
+        $<$<CONFIG:Debug>:${warnings-c}>
 )
-set_target_properties(segyio-static PROPERTIES
-                      OUTPUT_NAME ${STATIC_NAME}
-                      CLEAN_DIRECT_OUTPUT 1)
-target_include_directories(
-    segyio-static PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:include>
-    PRIVATE src include)
-
-#
-# dynamic build
-#
-add_library(segyio-shared SHARED ${SOURCE_FILES} ${DLL_EXPORT_FILES})
-target_link_libraries(segyio-shared ${m} ${ws2})
-target_compile_options(segyio-shared BEFORE
-    PRIVATE $<$<CONFIG:Debug>:${warnings-c}> ${c99}
+target_compile_definitions(segyio
+    PRIVATE
+        ${htons}
+        ${mmap}
+        ${fstat}
+        ${ftello}
 )
-target_compile_definitions(segyio-shared PRIVATE
-    ${htons} ${mmap} ${fstat} ${ftello})
-set_target_properties(segyio-shared PROPERTIES
+set_target_properties(segyio
+                      PROPERTIES
                       SOVERSION   ${segyio_MAJOR}
                       VERSION     ${segyio_MAJOR}
-                      OUTPUT_NAME segyio
-                      CLEAN_DIRECT_OUTPUT 1)
-target_include_directories(
-    segyio-shared PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:include>
-    PRIVATE src include)
-
-if (BUILD_SHARED_LIBS)
-    add_library(segyio ALIAS segyio-shared)
-else ()
-    add_library(segyio ALIAS segyio-static)
-    set_property(TARGET segyio-static PROPERTY POSITION_INDEPENDENT_CODE ON)
-endif ()
+)
+target_include_directories(segyio
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+        $<INSTALL_INTERFACE:include>
+    PRIVATE
+        src
+        include
+)
 
 #
 # install & export
 #
-install(TARGETS segyio-static segyio-shared
+install(TARGETS segyio
         EXPORT segyio
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+)
 install(DIRECTORY include/ DESTINATION include)
 install(EXPORT segyio
         DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/segyio/cmake
         FILE segyio-config.cmake
 )
-export(TARGETS segyio-static segyio-shared FILE segyio-config.cmake)
+export(TARGETS segyio FILE segyio-config.cmake)
 
 if (NOT BUILD_TESTING)
     return ()
@@ -82,10 +58,14 @@ configure_file(${testdata}/text.sgy  test-data/text.sgy              COPYONLY)
 
 add_executable(c.segy test/testsuite.cpp
                       test/segy.cpp
-                      test/mmap.cpp)
+                      test/mmap.cpp
+)
 target_include_directories(c.segy PRIVATE src)
 target_link_libraries(c.segy catch2 segyio)
 target_compile_options(c.segy BEFORE PRIVATE
-                       ${c++11} $<$<CONFIG:Debug>:${warnings-c}> ${mmap})
+    ${c++11}
+    ${mmap}
+    $<$<CONFIG:Debug>:${warnings-c}>
+)
 add_test(NAME c.segy COMMAND c.segy ~[mmap] [c.segy])
 add_test(NAME c.segy.mmap COMMAND c.segy [mmap])

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -66,7 +66,10 @@ install(TARGETS segyio-static segyio-shared
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 install(DIRECTORY include/ DESTINATION include)
-install(EXPORT segyio DESTINATION share/segyio/cmake FILE segyio-config.cmake)
+install(EXPORT segyio
+        DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/segyio/cmake
+        FILE segyio-config.cmake
+)
 export(TARGETS segyio-static segyio-shared FILE segyio-config.cmake)
 
 if (NOT BUILD_TESTING)

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -30,16 +30,16 @@ if (NOT WIN32)
     # setuptools on microsoft compilers doesn't support the --library-dir or
     # --build-dir flag and crashes, so only pass it on non-microsoft platforms
     set(setup-py-libdir build_ext
-                            --rpath        $<TARGET_FILE_DIR:segyio-shared>
-                            --library-dirs $<TARGET_FILE_DIR:segyio-shared>)
+                            --rpath        $<TARGET_FILE_DIR:segyio>
+                            --library-dirs $<TARGET_FILE_DIR:segyio>)
 
     set(install-no-rpath install_lib --build-dir build/install)
-    set(build-no-rpath --library-dirs $<TARGET_FILE_DIR:segyio-shared>
+    set(build-no-rpath --library-dirs $<TARGET_FILE_DIR:segyio>
                        build --build-lib build/install)
 else ()
     set(copy-dll-to-src ${CMAKE_COMMAND} -E
-        copy $<TARGET_FILE:segyio-shared>
-        ${CMAKE_CURRENT_SOURCE_DIR}/segyio/$<TARGET_FILE_NAME:segyio-shared>)
+        copy $<TARGET_FILE:segyio>
+        ${CMAKE_CURRENT_SOURCE_DIR}/segyio/$<TARGET_FILE_NAME:segyio>)
 endif ()
 
 
@@ -67,11 +67,11 @@ add_custom_target(
     # available in the same directory, and build_ext --library-dirs is not
     # support on msvc is not supported, so we must copy out the libsegyio core
     # object and put it here
-    COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:segyio-shared>
-                                     $<TARGET_FILE_NAME:segyio-shared>
+    COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:segyio>
+                                     $<TARGET_FILE_NAME:segyio>
 
-    COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_LINKER_FILE:segyio-shared>
-                                     $<TARGET_LINKER_FILE_NAME:segyio-shared>
+    COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_LINKER_FILE:segyio>
+                                     $<TARGET_LINKER_FILE_NAME:segyio>
 
     # on windows, copy the freshly-built dll to the source directory. this
     # voilates the cmake spirit (as does the version.py writing from
@@ -93,7 +93,7 @@ add_custom_target(
     COMMAND ${python} ${setup-py} build_ext ${build-no-rpath}
 )
 
-add_dependencies(segyio-python segyio-shared)
+add_dependencies(segyio-python segyio)
 
 # write egg_info to the build dir in order not to pollute the source directory
 # and install as if it was through some other distro by using single-version,

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,10 @@ def src(x):
     root = os.path.dirname( __file__ )
     return os.path.abspath(os.path.join(root, x))
 
-extra_libs = ['m'] if not 'win' in sys.platform else []
+if 'win' in sys.platform:
+    extra_libs = []
+else:
+    extra_libs = ['m']
 
 def getversion():
     # if this is a tarball distribution, the .git-directory won't be avilable


### PR DESCRIPTION
No longer build both shared- and static objects by default. Instead,
properly respect the BUILD_SHARED_LIBS option.

The main motivation for this is to make the segyio-config.cmake behave
properly, and not allow downstream users to choose what to link against.

A nice side effect is simpler make files with less non-standard
configuration, and a simpler flow.