### PR TITLE
Get cmake3.x from pip in manylinux image

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -13,21 +13,14 @@ function pre_build {
     if [ -d build-centos5 ]; then return; fi
 
     # the cmakes available in yum for centos5 are too old (latest 2.11.x), so
-    # do a dirty hack and get a pre-compiled i386-binary from cmake.org and run
-    # it. it's only necessary in the multilinux docker container and hopefully
-    # only until multilinux2 images are released
+    # fetch a newer version pypi
+    python -m pip install cmake
 
     mkdir build-centos5
     pushd build-centos5
 
-    # the cmake binary is compiled for 686, and the centos5 docker image does
-    # not provide libc.i686 by default
-    yum install -y glibc.i686
-    export cmake=cmake-2.8.12.2-Linux-i386
-    curl -o $cmake.tar.gz https://cmake.org/files/v2.8/cmake-2.8.12.2-Linux-i386.tar.gz
-    tar xzvf $cmake.tar.gz
-    ./$cmake/bin/cmake --version
-    ./$cmake/bin/cmake .. -DBUILD_PYTHON=OFF -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON
+    cmake --version
+    cmake .. -DBUILD_PYTHON=OFF -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON
     make install
     popd
 }

--- a/python/docs/conf.py
+++ b/python/docs/conf.py
@@ -45,7 +45,23 @@ extensions = [
 
 autosummary_generate = True
 add_module_names = False
-autodoc_default_flags = ['members', 'inherited-members']
+
+# sphinx 1.8 deprecates autodoc_default_flags. docs should be buildable with
+# warnings-as-errors, but the docs really don't require more than sphinx 1.5.
+# use the new autodoc config if built with >= 1.8
+#
+# ref http://luc.lino-framework.org/blog/2018/0821.html
+
+from distutils.version import LooseVersion
+import sphinx
+
+if LooseVersion(sphinx.__version__) < LooseVersion("1.8"):
+    autodoc_default_flags = ['members', 'inherited-members']
+else:
+    autodoc_default_options = {
+        'members': None,
+        'inherited-members': None,
+    }
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']


### PR DESCRIPTION
Instead of downloading a pre-built binary in a tarball, get cmake from
the pip infrastructure. This is a manylinux image, built in the same
image as the segyio binary package.

While code-wise this is a simple change, it's a step towards bumping the
minimum require cmake version from 2.8.12 to the 3.x series.