### PR TITLE
Two phase init python fd

### DIFF
--- a/python/segyio/open.py
+++ b/python/segyio/open.py
@@ -2,7 +2,7 @@ import numpy
 
 import segyio
 
-def infer_geometry(f, strict, metrics, iline, xline, strict):
+def infer_geometry(f, metrics, iline, xline, strict):
     try:
         cube_metrics = f.xfd.cube_metrics(iline, xline)
         f._sorting   = cube_metrics['sorting']
@@ -151,8 +151,17 @@ def open(filename, mode="r", iline = 189,
         solution = 'use r+ to open in read-write'
         raise ValueError(', '.join((problem, solution)))
 
-    f = segyio.SegyFile(filename, mode, iline, xline)
-    metrics = f.xfd.metrics()
+    from . import _segyio
+    fd = _segyio.segyiofd(str(filename), mode)
+    fd.segyopen()
+    metrics = fd.metrics()
+
+    f = segyio.SegyFile(fd,
+            filename = str(filename),
+            mode = mode,
+            iline = iline,
+            xline = xline,
+    )
 
     try:
         dt = segyio.tools.dt(f, fallback_dt = 4000.0) / 1000.0

--- a/python/segyio/segy.py
+++ b/python/segyio/segy.py
@@ -23,7 +23,7 @@ class SegyFile(object):
 
     _unstructured_errmsg = "File opened in unstructured mode."
 
-    def __init__(self, filename, mode, iline=189, xline=193, tracecount=0, binary=None):
+    def __init__(self, fd, filename, mode, iline=189, xline=193):
         self._filename = filename
         self._mode = mode
         self._il = iline
@@ -42,12 +42,7 @@ class SegyFile(object):
         self._xline_length = None
         self._xline_stride = None
 
-        from . import _segyio
-
-        self.xfd = _segyio.segyiofd(str(filename), mode,
-                                    tracecount=tracecount,
-                                    binary=binary,
-                                   )
+        self.xfd = fd
         metrics = self.xfd.metrics()
         self._fmt = metrics['format']
         self._tracecount = metrics['tracecount']

--- a/python/test/segyio_c.py
+++ b/python/test/segyio_c.py
@@ -110,14 +110,16 @@ def write_text_header(f, mmap):
 def get_instance_segyiofd(tmpdir,
                           file_name="small.sgy",
                           mode="r+",
-                          tracecount=0,
-                          binary=None):
+                          samples = None,
+                          tracecount = None,
+                          ):
     path = str(tmpdir)
     f = os.path.join(path, file_name)
-    if binary is not None:
-        return _segyio.segyiofd(f, mode, tracecount, binary)
+
+    if samples is not None:
+        return _segyio.segyiofd(f, mode).segymake(samples, tracecount)
     else:
-        return _segyio.segyiofd(f, mode)
+        return _segyio.segyiofd(f, mode).segyopen()
 
 
 @tmpfiles("test-data/small.sgy")
@@ -173,7 +175,7 @@ def test_line_metrics_mmap():
 
 
 def test_line_metrics(mmap=False):
-    f = _segyio.segyiofd("test-data/small.sgy", "r")
+    f = _segyio.segyiofd("test-data/small.sgy", "r").segyopen()
     if mmap:
         f.mmap()
 
@@ -217,7 +219,7 @@ def test_metrics_mmap():
 
 
 def test_metrics(mmap=False):
-    f = _segyio.segyiofd("test-data/small.sgy", "r")
+    f = _segyio.segyiofd("test-data/small.sgy", "r").segyopen()
     if mmap:
         f.mmap()
 
@@ -249,7 +251,7 @@ def test_indices_mmap():
 
 
 def test_indices(mmap=False):
-    f = _segyio.segyiofd("test-data/small.sgy", "r")
+    f = _segyio.segyiofd("test-data/small.sgy", "r").segyopen()
     if mmap:
         f.mmap()
 
@@ -303,7 +305,7 @@ def test_fread_trace0_mmap():
 
 
 def test_fread_trace0(mmap=False):
-    f = _segyio.segyiofd("test-data/small.sgy", "r")
+    f = _segyio.segyiofd("test-data/small.sgy", "r").segyopen()
     if mmap:
         f.mmap()
 
@@ -427,21 +429,23 @@ def read_and_write_traceheader(f, mmap):
 
 @tmpfiles("test-data/small.sgy")
 def test_read_and_write_trace_mmap(tmpdir):
-    binary = bytearray(_segyio.binsize())
-    _segyio.putfield(binary, 3221, 25)
-    f = get_instance_segyiofd(tmpdir, "trace-wrt.sgy", "w+",
-                              tracecount=100,
-                              binary=binary)
+    f = get_instance_segyiofd(tmpdir,
+        "trace-wrt.sgy",
+        "w+",
+        samples = 25,
+        tracecount = 100,
+    )
     read_and_write_trace(f, True)
 
 
 @tmpfiles("test-data/small.sgy")
 def test_read_and_write_trace(tmpdir):
-    binary = bytearray(_segyio.binsize())
-    _segyio.putfield(binary, 3221, 25)
-    f = get_instance_segyiofd(tmpdir, "trace-wrt.sgy", "w+",
-                              tracecount=100,
-                              binary=binary)
+    f = get_instance_segyiofd(tmpdir,
+            "trace-wrt.sgy",
+            "w+",
+            samples = 25,
+            tracecount = 100,
+    )
     read_and_write_trace(f, False)
 
 
@@ -502,7 +506,7 @@ def read_line(f, metrics, iline_idx, xline_idx):
 
 
 def read_small(mmap=False):
-    f = _segyio.segyiofd("test-data/small.sgy", "r")
+    f = _segyio.segyiofd("test-data/small.sgy", "r").segyopen()
 
     if mmap:
         f.mmap()


### PR DESCRIPTION

Use two-phase init for python file handle

Split the python file handle initialisation routine into two phases -
one for the physical, on-disk open, and one for filling out meta-data.
In short, instead of the previous interface of:
```
    fd = segyio.SegyFile(...)
```
it's now necessary to do:
```
    fd = _segyio.segyiofd(...)
    fd.segyopen()

    fd = _segyio.segyiofd(...)
    fd.segymake(...)
```
for opening and making files, respectively. This does not leak into user
code, and is taken care of inside open and create.

This properly splits the open/create routines into separate functions,
instead of interleaving them with conditionals. This is a readability
win, at the cost of some minor duplication.