### PR TITLE
Call write, not read, in mmap write-trace

### DIFF
--- a/lib/src/segy.c
+++ b/lib/src/segy.c
@@ -1473,8 +1473,8 @@ int segy_writesubtr( segy_file* fp,
          * be handled by the stride-aware code path
          */
         if( fp->addr ) {
-            err = memread( fp, fp->cur, buf, elemsize * elems );
-            if( err != SEGY_OK ) return err;
+            err = memwrite( fp, fp->cur, buf, elemsize * elems );
+            if( err ) return err;
         } else {
             const int writec = fwrite( buf, elemsize, elems, fp->fp );
             if( writec != elems ) return SEGY_FWRITE_ERROR;

--- a/lib/test/segy.cpp
+++ b/lib/test/segy.cpp
@@ -1,3 +1,4 @@
+#include <fstream>
 #include <numeric>
 #include <cmath>
 #include <memory>
@@ -14,6 +15,22 @@
 #endif
 
 namespace {
+
+const std::string& copyfile( const std::string& src, const std::string& dst ) {
+    std::ifstream  in( src, std::ios::binary );
+    std::ofstream out( dst, std::ios::binary );
+
+    out << in.rdbuf();
+    return dst;
+}
+
+constexpr bool strequal( const char* x, const char* y ) {
+    return *x == *y && (*x == '\0' || strequal(x + 1, y + 1) );
+}
+
+constexpr bool mmapd() {
+    return !strequal( MMAP_TAG, "" );
+}
 
 struct slice { int start, stop, step; };
 std::string str( const slice& s ) {
@@ -830,7 +847,7 @@ TEST_CASE_METHOD( smallcube,
     CHECK_THAT( line, ApproxRange( expected ) );
 }
 
-template< int Start, int Stop, int Step >
+template< int Start, int Stop, int Step, bool memmap = mmapd() >
 struct writesubtr {
     segy_file* fp = nullptr;
 
@@ -855,13 +872,13 @@ struct writesubtr {
                          + "," + std::to_string( step )
                          + "].sgy";
 
-        fp = segy_open( name.c_str(), "w+b" );
+        copyfile( "test-data/small.sgy", name );
 
+        fp = segy_open( name.c_str(), "r+b" );
         REQUIRE( fp );
 
-        if( MMAP_TAG != std::string( "" ) )
-            REQUIRE( segy_mmap( fp ) );
-
+        if( memmap )
+            REQUIRE( success( segy_mmap( fp ) ) );
 
         trace.assign( 50, 0 );
         expected.resize( trace.size() );

--- a/python/segyio/segy.py
+++ b/python/segyio/segy.py
@@ -750,36 +750,6 @@ class SegyFile(object):
         Notes
         -----
         .. versionadded:: 1.1
-
-        Examples
-        --------
-
-        Print the textual header:
-
-        >>> print(f.text[0])
-
-        Print the first extended textual header:
-
-        >>> print(f.text[1])
-
-        Write a new textual header:
-
-        >>> f.text[0] = make_new_header()
-
-        Copy a tectual header:
-
-        >>> f.text[1] = g.text[0]
-
-        Print a textual header line-by-line:
-
-        >>> # using zip, from the zip documentation
-        >>> text = str(f.text[0])
-        >>> lines = map(''.join, zip( *[iter(text)] * 80))
-        >>> for line in lines:
-        ...     print(line)
-        ...
-
-
         """
         return Text(self.xfd, self._ext_headers + 1)
 


### PR DESCRIPTION
The wrong function (!) was called here, meaning memeory mapped writes
never really worked as expected. This was not caught by a test, because
the tests for this function use new files, and memory freshly-created
files has never been supported.

The write-sub-trace tests have been amended to also work with
memory-mapping. The new strategy for these tests to make a test-specific
copy of the small.sgy file, and open it in read-write mode, instead of
creating a new truncated test-specific file as before.