### PR TITLE
Move custom matchers to includable file

### DIFF
--- a/lib/test/matchers.hpp
+++ b/lib/test/matchers.hpp
@@ -1,0 +1,37 @@
+#ifndef SEGYIO_MATCHERS_HPP
+#define SEGYIO_MATCHERS_HPP
+
+#include <catch/catch.hpp>
+
+#include <string>
+#include <vector>
+
+namespace {
+
+class ApproxRange : public Catch::MatcherBase< std::vector< float > > {
+    public:
+        explicit ApproxRange( const std::vector< float >& xs ) :
+            lhs( xs )
+        {}
+
+        virtual bool match( const std::vector< float >& xs ) const override {
+            if( xs.size() != lhs.size() ) return false;
+
+            for( std::size_t i = 0; i < xs.size(); ++i )
+                if( xs[ i ] != Approx(this->lhs[ i ]) ) return false;
+
+            return true;
+        }
+
+        virtual std::string describe() const override {
+            using str = Catch::StringMaker< std::vector< float > >;
+            return "~= " + str::convert( this->lhs );
+        }
+
+    private:
+        std::vector< float > lhs;
+};
+
+}
+
+#endif // SEGYIO_MATCHERS_HPP

--- a/lib/test/segy.cpp
+++ b/lib/test/segy.cpp
@@ -5,6 +5,7 @@
 #include <vector>
 
 #include <catch/catch.hpp>
+#include "matchers.hpp"
 
 #include <segyio/segy.h>
 #include <segyio/util.h>
@@ -22,30 +23,6 @@ std::string str( const slice& s ) {
            "," + std::to_string( s.step ) +
            ")";
 }
-
-class ApproxRange : public Catch::MatcherBase< std::vector< float > > {
-    public:
-        explicit ApproxRange( const std::vector< float >& xs ) :
-            lhs( xs )
-        {}
-
-        virtual bool match( const std::vector< float >& xs ) const override {
-            if( xs.size() != lhs.size() ) return false;
-
-            for( size_t i = 0; i < xs.size(); ++i )
-                if( xs[ i ] != Approx(this->lhs[ i ]) ) return false;
-
-            return true;
-        }
-
-        virtual std::string describe() const override {
-            using str = Catch::StringMaker< std::vector< float > >;
-            return "~= " + str::convert( this->lhs );
-        }
-
-    private:
-        std::vector< float > lhs;
-};
 
 struct Err {
     // cppcheck-suppress noExplicitConstructor


### PR DESCRIPTION
Move the custom matchers to a matchers.hpp to enable re-use across test
units.