### PR TITLE
Depth slice shape fast by slow

### DIFF
--- a/python/docs/segyio.rst
+++ b/python/docs/segyio.rst
@@ -26,9 +26,12 @@ Data trace
 .. autoclass:: segyio.trace.RefTrace()
     :special-members: __getitem__, __setitem__, __len__, __contains__, __iter__
 
-Trace header
-------------
+Trace header and attributes
+---------------------------
 .. autoclass:: segyio.trace.Header()
+    :special-members: __getitem__, __setitem__, __len__, __contains__, __iter__
+
+.. autoclass:: segyio.trace.Attributes()
     :special-members: __getitem__, __setitem__, __len__, __contains__, __iter__
 
 Data line
@@ -49,6 +52,11 @@ Gather
 Depth
 -----
 .. autoclass:: segyio.depth.Depth()
+    :special-members: __getitem__, __setitem__, __len__, __contains__, __iter__
+
+Text
+----
+.. autoclass:: segyio.trace.Text()
     :special-members: __getitem__, __setitem__, __len__, __contains__, __iter__
 
 Trace and binary header

--- a/python/segyio/depth.py
+++ b/python/segyio/depth.py
@@ -14,12 +14,19 @@ class Depth(Sequence):
     that SEG-Y data is laid out trace-by-trace on disk, so accessing horizontal
     cuts (fixed z-coordinates in a cartesian grid) is *very* inefficient.
 
+    This mode works even on unstructured files, because it is not reliant on
+    in/crosslines to be sensible. Please note that in the case of unstructured
+    depth slicing, the array shape == tracecount.
+
     Notes
     -----
     .. versionadded:: 1.1
 
     .. versionchanged:: 1.6
         common list operations (collections.Sequence)
+
+    .. versionchanged:: 1.7.1
+       enabled for unstructured files
 
     .. warning::
         Accessing the file by depth (fixed z-coordinate) is inefficient because
@@ -34,10 +41,10 @@ class Depth(Sequence):
 
         if fd.unstructured:
             self.shape = fd.tracecount
+            self.offsets = 1
         else:
             self.shape = (len(fd.fast), len(fd.slow))
-
-        self.offsets = len(fd.offsets)
+            self.offsets = len(fd.offsets)
 
     def __getitem__(self, i):
         """depth[i]
@@ -48,8 +55,9 @@ class Depth(Sequence):
 
         When i is a slice, a generator of numpy.ndarray is returned.
 
-        The depth slices are returned as a fast-by-slow array, i.e. an inline
-        sorted file with 10 inlines and 5 crosslines has the shape (10,5).
+        The depth slices are returned as a fast-by-slow shaped array, i.e. an
+        inline sorted file with 10 inlines and 5 crosslines has the shape
+        (10,5). If the file is unsorted, the array shape == tracecount.
 
         Parameters
         ----------

--- a/python/segyio/depth.py
+++ b/python/segyio/depth.py
@@ -34,10 +34,8 @@ class Depth(Sequence):
 
         if fd.unstructured:
             self.shape = fd.tracecount
-        elif fd.sorting == Sorting.CROSSLINE_SORTING:
-            self.shape = (len(fd.ilines), len(fd.xlines))
         else:
-            self.shape = (len(fd.xlines), len(fd.ilines))
+            self.shape = (len(fd.fast), len(fd.slow))
 
         self.offsets = len(fd.offsets)
 
@@ -50,6 +48,9 @@ class Depth(Sequence):
 
         When i is a slice, a generator of numpy.ndarray is returned.
 
+        The depth slices are returned as a fast-by-slow array, i.e. an inline
+        sorted file with 10 inlines and 5 crosslines has the shape (10,5).
+
         Parameters
         ----------
         i : int or slice
@@ -61,6 +62,13 @@ class Depth(Sequence):
         Notes
         -----
         .. versionadded:: 1.1
+
+        .. warning::
+            The segyio 1.5 and 1.6 series, and 1.7.0, would return the depth_slice in the
+            wrong shape for most files. Since segyio 1.7.1, the arrays have the
+            correct shape, i.e. fast-by-slow. The underlying data was always
+            fast-by-slow, so a numpy array reshape can fix programs using the
+            1.5 and 1.6 series.
 
         Behaves like [] for lists.
 
@@ -83,6 +91,11 @@ class Depth(Sequence):
 
         >>> for d in depth[:250]:
         ...     d.mean()
+
+        >>> len(ilines), len(xlines)
+        (1, 6)
+        >>> f.depth_slice[0]
+        array([[0.  , 0.01, 0.02, 0.03, 0.04, 0.05]], dtype=float32)
         """
 
         try:

--- a/python/segyio/segy.py
+++ b/python/segyio/segy.py
@@ -668,15 +668,19 @@ class SegyFile(object):
     @property
     def depth_slice(self):
         """
-        Interact with segy in depth slice mode
+        Interact with segy in depth slice mode (fixed z-coordinate)
 
         Returns
         -------
         depth : Depth
-        """
 
-        if self.unstructured:
-            raise ValueError(self._unstructured_errmsg)
+        Notes
+        -----
+        .. versionadded:: 1.1
+
+        .. versionchanged:: 1.7.1
+            enabled for unstructured files
+        """
 
         if self.depth is not None:
             return self.depth

--- a/python/test/segy.py
+++ b/python/test/segy.py
@@ -1397,6 +1397,10 @@ def test_depth_slice_reading():
     with pytest.raises(IndexError):
         _ = f.depth_slice[len(f.samples)]
 
+def test_depth_slice_array_shape():
+    with segyio.open("test-data/1xN.sgy") as f:
+        shape = (len(f.fast), len(f.slow))
+        assert f.depth_slice.shape == shape
 
 @tmpfiles("test-data/small.sgy")
 def test_depth_slice_writing(tmpdir):

--- a/python/test/segy.py
+++ b/python/test/segy.py
@@ -782,9 +782,6 @@ def test_open_fails_unstructured():
         with pytest.raises(ValueError):
             _ = f.xline[:, :]
 
-        with pytest.raises(ValueError):
-            _ = f.depth_slice[2]
-
         # operations that don't rely on geometry still works
         assert f.header[2][189] == 1
         assert (list(f.attributes(189)[:]) ==
@@ -1401,6 +1398,13 @@ def test_depth_slice_array_shape():
     with segyio.open("test-data/1xN.sgy") as f:
         shape = (len(f.fast), len(f.slow))
         assert f.depth_slice.shape == shape
+
+def test_depth_slice_unstructured():
+    with segyio.open("test-data/small.sgy", ignore_geometry = True) as f:
+        traces = f.trace.raw[:]
+        shape = len(f.trace)
+        assert f.depth_slice.shape == shape
+        np.testing.assert_almost_equal(f.depth_slice[0], traces[:,0])
 
 @tmpfiles("test-data/small.sgy")
 def test_depth_slice_writing(tmpdir):


### PR DESCRIPTION
Closes #306 

See #305 

## depth_slice.shape is always fast-by-slow

The directions for the slices got mixed up in 64476e7, which made the
shape of depth_slices wrong. The underlying read function goes in
increasing-trace order, or 'fast' direction, anything other than
fast-by-slow will be wrong.

## Enable depth_slice for unstructured files

There has been code supporting depth_slicing (fixed z-coordinate) across
the file for a long time, but it was protected with a ValueError
exception in the case of unstructured files. This restriction can be
lifted, as fixed z-coordinate access is perfectly reasonable even
without a proper volume.