### PR TITLE
Create tmpfiles with pytest.fixtures

### DIFF
--- a/python/test/__init__.py
+++ b/python/test/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import shutil
-import os
+import pytest
 
 def tmpfiles(*files):
     def tmpfiles_decorator(func):
@@ -11,3 +11,15 @@ def tmpfiles(*files):
             func(tmpdir)
         return func_wrapper
     return tmpfiles_decorator
+
+
+@pytest.fixture
+def small(tmpdir):
+    shutil.copy("test-data/small.sgy", str(tmpdir))
+    return tmpdir / "small.sgy"
+
+
+@pytest.fixture
+def smallps(tmpdir):
+    shutil.copy("test-data/small-ps.sgy", str(tmpdir))
+    return tmpdir / "small-ps.sgy"


### PR DESCRIPTION
These fixtures provide a fixed baseline for creation of temporary
small.sgy and small-ps.sgy which is used for several test-functions