### PR TITLE
Method for (re)interpret structure on an open file

### DIFF
--- a/python/segyio/open.py
+++ b/python/segyio/open.py
@@ -11,28 +11,12 @@ def infer_geometry(f, metrics, iline, xline, strict):
         offset_count = cube_metrics['offset_count']
         metrics.update(cube_metrics)
 
-        line_metrics = segyio._segyio.line_metrics(f.sorting,
-                                                   f.tracecount,
-                                                   iline_count,
-                                                   xline_count,
-                                                   offset_count)
+        ilines  = numpy.zeros(iline_count,  dtype=numpy.intc)
+        xlines  = numpy.zeros(xline_count,  dtype=numpy.intc)
+        offsets = numpy.zeros(offset_count, dtype=numpy.intc)
 
-        f._iline_length = line_metrics['iline_length']
-        f._iline_stride = line_metrics['iline_stride']
-
-        f._xline_length = line_metrics['xline_length']
-        f._xline_stride = line_metrics['xline_stride']
-
-        f._ilines  = numpy.zeros(iline_count,  dtype = numpy.intc)
-        f._xlines  = numpy.zeros(xline_count,  dtype = numpy.intc)
-        f._offsets = numpy.zeros(offset_count, dtype = numpy.intc)
-        f.xfd.indices(metrics, f.ilines, f.xlines, f.offsets)
-
-        if numpy.unique(f.ilines).size != f.ilines.size:
-            raise ValueError( "Inlines inconsistent - expect all inlines to be unique")
-
-        if numpy.unique(f.xlines).size != f.xlines.size:
-            raise ValueError( "Crosslines inconsistent - expect all crosslines to be unique")
+        f.xfd.indices(metrics, ilines, xlines, offsets)
+        f.interpret(ilines, xlines, offsets, f._sorting)
 
     except:
         if not strict:
@@ -44,6 +28,7 @@ def infer_geometry(f, metrics, iline, xline, strict):
             raise
 
     return f
+
 
 def open(filename, mode="r", iline = 189,
                              xline = 193,

--- a/python/test/segy.py
+++ b/python/test/segy.py
@@ -1544,3 +1544,21 @@ def test_utf8_filename():
 def test_utf8_filename_pypath(tmpdir):
     with segyio.open(tmpdir / '小文件.sgy') as f:
         assert list(f.ilines) == [1, 2, 3, 4, 5]
+
+
+def test_interpret_invalid_args():
+    with segyio.open("test-data/small.sgy", ignore_geometry=True) as f:
+        with pytest.raises(ValueError):
+            il = [1, 2, 3, 4]
+            xl = [20, 21, 22, 23, 24]
+            f.interpret(il, xl)
+
+        with pytest.raises(ValueError):
+            il = [1, 2, 3, 4, 5]
+            xl = [20, 21, 22, 23, 24]
+            f.interpret(il, xl, sorting=0)
+
+        with pytest.raises(ValueError):
+            il = [1, 2, 3, 4, 4]
+            xl = [20, 21, 22, 23, 24]
+            f.interpret(il, xl, sorting=0)


### PR DESCRIPTION
Given a set off structure-defining parameters interpret() will
(re)interpret the structure of the file. This does not change the
file itself, it only changes segyio's interpretation of it.
Connects to #294 