### PR TITLE
Parameterise tests as separate processes, not tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,6 @@ addons:
         - sourceline: 'ppa:jokva/backports'
         - george-edison55-precise-backports # cmake 3
       packages:
-        - valgrind
         - cppcheck
         - cmake
         - cmake-data

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -65,16 +65,20 @@ configure_file(${testdata}/text.sgy  test-data/text.sgy              COPYONLY)
 
 add_executable(c.segy test/testsuite.cpp
                       test/segy.cpp
-                      test/mmap.cpp
                       test/segyio-cpp.cpp
 )
 target_include_directories(c.segy PRIVATE src experimental)
 target_link_libraries(c.segy catch2 segyio)
-target_compile_options(c.segy BEFORE PRIVATE
-    ${c++11}
-    ${mmap}
-    $<$<CONFIG:Debug>:${warnings-c}>
+target_compile_options(c.segy BEFORE
+    PRIVATE
+        ${c++11}
+        ${mmap}
+        $<$<CONFIG:Debug>:${warnings-c}>
 )
-add_test(NAME c.segy      COMMAND c.segy ~[mmap] [c.segy])
-add_test(NAME c.segy.mmap COMMAND c.segy [mmap])
+target_compile_definitions(c.segy
+    PRIVATE
+        ${mmap}
+)
+add_test(NAME c.segy      COMMAND c.segy)
+add_test(NAME c.segy.mmap COMMAND c.segy --test-mmap)
 add_test(NAME cpp.segy    COMMAND c.segy [c++])

--- a/lib/test/mmap.cpp
+++ b/lib/test/mmap.cpp
@@ -1,6 +1,0 @@
-#ifdef HAVE_MMAP
-
-#define MMAP_TAG "[mmap] "
-#include "segy.cpp"
-
-#endif //HAVE_MMAP

--- a/lib/test/test-config.hpp
+++ b/lib/test/test-config.hpp
@@ -1,0 +1,13 @@
+#ifndef SEGYIO_TEST_CONFIG_HPP
+#define SEGYIO_TEST_CONFIG_HPP
+#include <segyio/segy.h>
+
+struct testcfg {
+    void apply( segy_file* );
+
+    static testcfg& config();
+
+    bool memmap = false;
+};
+
+#endif // SEGYIO_TEST_CONFIG_HPP

--- a/lib/test/testsuite.cpp
+++ b/lib/test/testsuite.cpp
@@ -1,2 +1,37 @@
-#define CATCH_CONFIG_MAIN
+#define CATCH_CONFIG_RUNNER
 #include <catch/catch.hpp>
+
+#include <segyio/segy.h>
+
+#include "test-config.hpp"
+
+void testcfg::apply( segy_file* fp ) {
+    if( this->memmap ) {
+    #ifdef HAVE_MMAP
+        REQUIRE( segy_mmap( fp ) == SEGY_OK );
+    #endif //HAVE_MMAP
+    }
+}
+
+testcfg& testcfg::config() {
+    static testcfg s;
+    return s;
+}
+
+int main( int argc, char** argv ) {
+      Catch::Session session;
+
+      auto& cfg = testcfg::config();
+
+      using namespace Catch::clara;
+      auto cli = session.cli()
+          | Opt( cfg.memmap ) ["--test-mmap"] ("run with memory mapped files")
+          ;
+      session.cli( cli );
+
+      const int errc = session.applyCommandLine( argc, argv );
+      if( errc )
+          return errc;
+
+      return session.run();
+}


### PR DESCRIPTION
Replace the include src.cpp way of parameterising tests with multiple
processes, a global config object, and command line options.

Every include would essentially add a constant compile time increase,
which is over time unsustainable (I measured compilation time to approx
3.5s per file on my laptop, which is excessive for 1500 lines).

Additionally, it made code ugly because every test tag has to be unique,
which was solved by defining a tag and prepending it to every test. This
does not compose too nicely, and would get increasingly worse.

There *will* be more cases of tests essentially being identical, except
some slight configuration change on the file handle. It's desirable to
run also these configurations through the full test suite.

Running the multiple configurations is now handled by cmake, rather than
implicitly by catch and the compiler.