### PR TITLE
Suppress false positive null-deref in catch

### DIFF
--- a/external/catch2/catch/catch.hpp
+++ b/external/catch2/catch/catch.hpp
@@ -4736,8 +4736,17 @@ namespace Catch {
 
     inline IMutableContext& getCurrentMutableContext()
     {
+        /*
+         * False positive reported here:
+         * https://github.com/catchorg/Catch2/issues/1230
+         *
+         * and upstream: https://bugs.llvm.org/show_bug.cgi?id=39201
+         */
+        #ifndef __clang_analyzer__
         if( !IMutableContext::currentContext )
             IMutableContext::createContext();
+        #endif
+
         return *IMutableContext::currentContext;
     }
 


### PR DESCRIPTION
This false positive came with the release of clang-7 and is documented
both upstream at Catch and upstream at LLVM. For now, just suppress it,
as it breaks travis builds and provides no extra information.