### PR TITLE
Use f.interpret() in segyio.create()

### DIFF
--- a/python/segyio/create.py
+++ b/python/segyio/create.py
@@ -207,23 +207,7 @@ def create(filename, spec):
     f._samples       = samples
 
     if structured(spec):
-        f._sorting       = spec.sorting
-        f._offsets       = numpy.copy(numpy.asarray(spec.offsets, dtype = numpy.intc))
-
-        f._ilines        = numpy.copy(numpy.asarray(spec.ilines, dtype=numpy.intc))
-        f._xlines        = numpy.copy(numpy.asarray(spec.xlines, dtype=numpy.intc))
-
-        line_metrics = _segyio.line_metrics(f.sorting,
-                                            tracecount,
-                                            len(f.ilines),
-                                            len(f.xlines),
-                                            len(f.offsets))
-
-        f._iline_length = line_metrics['iline_length']
-        f._iline_stride = line_metrics['iline_stride']
-
-        f._xline_length = line_metrics['xline_length']
-        f._xline_stride = line_metrics['xline_stride']
+        f.interpret(spec.ilines, spec.xlines, spec.offsets, spec.sorting)
 
     f.text[0] = default_text_header(f._il, f._xl, segyio.TraceField.offset)
 

--- a/python/segyio/segy.py
+++ b/python/segyio/segy.py
@@ -900,9 +900,9 @@ class SegyFile(object):
         if offsets is None:
             offsets = np.arange(1)
 
-        ilines  = np.asarray(ilines,  dtype=np.intc)
-        xlines  = np.asarray(xlines,  dtype=np.intc)
-        offsets = np.asarray(offsets, dtype=np.intc)
+        ilines  = np.copy(np.asarray(ilines,  dtype=np.intc))
+        xlines  = np.copy(np.asarray(xlines,  dtype=np.intc))
+        offsets = np.copy(np.asarray(offsets, dtype=np.intc))
 
         if np.unique(ilines).size != ilines.size:
             error = "Inlines inconsistent"


### PR DESCRIPTION
interpret() assigns ilines, xlines, and offsets labels by copy rather
then by reference. This should have been the case for the original
implementation of interpret()

Connects to #294 
Closes #294