### PR TITLE
Ensure su-words are picked up by sphinx

### DIFF
--- a/python/docs/segyio.rst
+++ b/python/docs/segyio.rst
@@ -92,7 +92,7 @@ Binary header keys
 
 Seismic Unix keys
 -----------------
-.. automodule:: segyio.su
+.. automodule:: segyio.su.words
     :members:
     :undoc-members:
     :member-order: bysource

--- a/python/segyio/su/words.py
+++ b/python/segyio/su/words.py
@@ -20,129 +20,253 @@ Seismic Unix name.
 from ..tracefield import TraceField as tf
 from ..binfield import BinField as bf
 
-# trace
+# the wonky #: before every line is so that sphinx' autodoc picks it up, and includes the constants in the documentation
+
+#:
 tracl  = tf.TRACE_SEQUENCE_LINE
+#:
 tracr  = tf.TRACE_SEQUENCE_FILE
+#:
 fldr   = tf.FieldRecord
+#:
 tracf  = tf.TraceNumber
+#:
 ep     = tf.EnergySourcePoint
+#:
 cdp    = tf.CDP
+#:
 cdpt   = tf.CDP_TRACE
+#:
 trid   = tf.TraceIdentificationCode
+#:
 nvs    = tf.NSummedTraces
+#:
 nhs    = tf.NStackedTraces
+#:
 duse   = tf.DataUse
+#:
 offset = tf.offset
+#:
 gelev  = tf.ReceiverGroupElevation
+#:
 selev  = tf.SourceSurfaceElevation
+#:
 sdepth = tf.SourceDepth
+#:
 gdel   = tf.ReceiverDatumElevation
+#:
 sdel   = tf.SourceDatumElevation
+#:
 swdep  = tf.SourceWaterDepth
+#:
 gwdep  = tf.GroupWaterDepth
+#:
 scalel = tf.ElevationScalar
+#:
 scalco = tf.SourceGroupScalar
+#:
 sx     = tf.SourceX
+#:
 sy     = tf.SourceY
+#:
 gx     = tf.GroupX
+#:
 gy     = tf.GroupY
+#:
 counit = tf.CoordinateUnits
+#:
 wevel  = tf.WeatheringVelocity
+#:
 swevel = tf.SubWeatheringVelocity
+#:
 sut    = tf.SourceUpholeTime
+#:
 gut    = tf.GroupUpholeTime
+#:
 sstat  = tf.SourceStaticCorrection
+#:
 gstat  = tf.GroupStaticCorrection
+#:
 tstat  = tf.TotalStaticApplied
+#:
 laga   = tf.LagTimeA
+#:
 lagb   = tf.LagTimeB
+#:
 delrt  = tf.DelayRecordingTime
+#:
 muts   = tf.MuteTimeStart
+#:
 mute   = tf.MuteTimeEND
+#:
 ns     = tf.TRACE_SAMPLE_COUNT
+#:
 dt     = tf.TRACE_SAMPLE_INTERVAL
+#:
 gain   = tf.GainType
+#:
 igc    = tf.InstrumentGainConstant
+#:
 igi    = tf.InstrumentInitialGain
+#:
 corr   = tf.Correlated
+#:
 sfs    = tf.SweepFrequencyStart
+#:
 sfe    = tf.SweepFrequencyEnd
+#:
 slen   = tf.SweepLength
+#:
 styp   = tf.SweepType
+#:
 stat   = tf.SweepTraceTaperLengthStart
+#:
 stae   = tf.SweepTraceTaperLengthEnd
+#:
 tatyp  = tf.TaperType
+#:
 afilf  = tf.AliasFilterFrequency
+#:
 afils  = tf.AliasFilterSlope
+#:
 nofilf = tf.NotchFilterFrequency
+#:
 nofils = tf.NotchFilterSlope
+#:
 lcf    = tf.LowCutFrequency
+#:
 hcf    = tf.HighCutFrequency
+#:
 lcs    = tf.LowCutSlope
+#:
 hcs    = tf.HighCutSlope
+#:
 year   = tf.YearDataRecorded
+#:
 day    = tf.DayOfYear
+#:
 hour   = tf.HourOfDay
+#:
 minute = tf.MinuteOfHour
+#:
 sec    = tf.SecondOfMinute
+#:
 timbas = tf.TimeBaseCode
+#:
 trwf   = tf.TraceWeightingFactor
+#:
 grnors = tf.GeophoneGroupNumberRoll1
+#:
 grnofr = tf.GeophoneGroupNumberFirstTraceOrigField
+#:
 grnlof = tf.GeophoneGroupNumberLastTraceOrigField
+#:
 gaps   = tf.GapSize
+#:
 otrav  = tf.OverTravel
+#:
 cdpx   = tf.CDP_X
+#:
 cdpy   = tf.CDP_Y
+#:
 iline  = tf.INLINE_3D
+#:
 xline  = tf.CROSSLINE_3D
+#:
 sp     = tf.ShotPoint
+#:
 scalsp = tf.ShotPointScalar
+#:
 trunit = tf.TraceValueMeasurementUnit
+#:
 tdcm   = tf.TransductionConstantMantissa
+#:
 tdcp   = tf.TransductionConstantPower
+#:
 tdunit = tf.TransductionUnit
+#:
 triden = tf.TraceIdentifier
+#:
 sctrh  = tf.ScalarTraceHeader
+#:
 stype  = tf.SourceType
+#:
 sedm   = tf.SourceEnergyDirectionMantissa
+#:
 sede   = tf.SourceEnergyDirectionExponent
+#:
 smm    = tf.SourceMeasurementMantissa
+#:
 sme    = tf.SourceMeasurementExponent
+#:
 smunit = tf.SourceMeasurementUnit
+#:
 uint1  = tf.UnassignedInt1
+#:
 uint2  = tf.UnassignedInt2
 
 # binary
+#:
 jobid  = bf.JobID
+#:
 lino   = bf.LineNumber
+#:
 reno   = bf.ReelNumber
+#:
 ntrpr  = bf.Traces
+#:
 nart   = bf.AuxTraces
+#:
 hdt    = bf.Interval
+#:
 dto    = bf.IntervalOriginal
+#:
 hns    = bf.Samples
+#:
 nso    = bf.SamplesOriginal
+#:
 format = bf.Format
+#:
 fold   = bf.EnsembleFold
+#:
 tsort  = bf.SortingCode
+#:
 vscode = bf.VerticalSum
+#:
 hsfs   = bf.SweepFrequencyStart
+#:
 hsfe   = bf.SweepFrequencyEnd
+#:
 hslen  = bf.SweepLength
+#:
 hstyp  = bf.Sweep
+#:
 schn   = bf.SweepChannel
+#:
 hstas  = bf.SweepTaperStart
+#:
 hstae  = bf.SweepTaperEnd
+#:
 htatyp = bf.Taper
+#:
 hcorr  = bf.CorrelatedTraces
+#:
 bgrcv  = bf.BinaryGainRecovery
+#:
 rcvm   = bf.AmplitudeRecovery
+#:
 mfeet  = bf.MeasurementSystem
+#:
 polyt  = bf.ImpulseSignalPolarity
+#:
 vpol   = bf.VibratoryPolarity
+#:
 unas1  = bf.Unassigned1
+#:
 rev    = bf.SEGYRevision
+#:
 trflag = bf.TraceFlag
+#:
 exth   = bf.ExtendedHeaders
+#:
 unas2  = bf.Unassigned2


### PR DESCRIPTION
Sphinx isn't to helpful documenting undocumented module variables, so
help it on the way by adding empty special comments for every entry.