### PR TITLE
Write each trace only on time in HeaderLine

### DIFF
--- a/python/segyio/line.py
+++ b/python/segyio/line.py
@@ -427,7 +427,8 @@ class HeaderLine(Line):
 
         else:
             step = self.stride * len(self.offsets)
-            return self.header[start::step]
+            stop = start + step * self.length
+            return self.header[start:stop:step]
 
         def gen():
             irange, orange = self.ranges(index, offset)
@@ -496,7 +497,8 @@ class HeaderLine(Line):
                 pass
 
             step = self.stride * len(self.offsets)
-            self.header[start::step] = val
+            stop  = start + step * self.length
+            self.header[start:stop:step] = val
             return
 
         irange, orange = self.ranges(index, offset)


### PR DESCRIPTION
HeaderLine called Header with the wrong range, resulting in way to many
write operations when writing lines along the sorting  direction. I. e.
the same headers was written muliple times, tanking the performance.
Correcting the range reduced the function call complexity from  n^2
to n.

Example: Writing headers in iline mode on a iline sorted file:

1:        f.header.iline[n] = _

HeaderLine then called Header with:

2:       self.header[n0, :, stride] = _

where n0 is the first trace of iline n. In this case stride = 1, hence
we are writing all header from iline n to the end of the file. All
headers after line n is wronly assigned. However, in cases where the
entire file is updated with (1), the last assignment to each header
would still be correct, thus test has not picked up on this issue.

Connects to #329 
Closes #329