### PR TITLE
Fix typo in gather

### DIFF
--- a/python/segyio/gather.py
+++ b/python/segyio/gather.py
@@ -140,7 +140,7 @@ class Gather(object):
                 return
 
             if len(xs) == 0:
-                for _, _ in itertools.product(ilrange, xlrange): yield empty
+                for _, _ in itertools.product(il_range, xl_range): yield empty
                 return
 
             for ilno in il_range:

--- a/python/test/segy.py
+++ b/python/test/segy.py
@@ -508,6 +508,9 @@ def test_gather_mode():
             assert (2, 10) == g.shape
             assert np.array_equal(line[0], g[0])
 
+        for g, line in zip(f.gather[1, 1:3, 3:4], f.xline[1:3]):
+            assert np.array_equal(empty, g)
+
 
 def test_line_generators():
     with segyio.open("test-data/small.sgy") as f:


### PR DESCRIPTION
When operating on slices, if offset slice is out of range, empty array
should be returned.
Fixed typo, added test.