### PR TITLE
Change default segy.spec.sorting to inline

### DIFF
--- a/python/segyio/create.py
+++ b/python/segyio/create.py
@@ -2,6 +2,7 @@ import datetime
 import numpy
 import segyio
 
+from . import TraceSortingFormat
 
 def default_text_header(iline, xline, offset):
     lines = {
@@ -23,17 +24,14 @@ def structured(spec):
     if not hasattr(spec, 'ilines' ): return False
     if not hasattr(spec, 'xlines' ): return False
     if not hasattr(spec, 'offsets'): return False
-    if not hasattr(spec, 'sorting'): return False
 
     if spec.ilines  is None: return False
     if spec.xlines  is None: return False
     if spec.offsets is None: return False
-    if spec.sorting is None: return False
 
     if not list(spec.ilines):  return False
     if not list(spec.xlines):  return False
     if not list(spec.offsets): return False
-    if not int(spec.sorting):  return False
 
     return True
 
@@ -53,9 +51,9 @@ def create(filename, spec):
     Create should be used together with python's ``with`` statement. This ensure
     the data is written. Please refer to the examples.
 
-    The ``segyio.spec()`` function will default offsets and everything in the
-    mandatory group, except format and samples, and requires the caller to fill
-    in *all* the fields in either of the exclusive groups.
+    The ``segyio.spec()`` function will default sorting, offsets and everything
+    in the mandatory group, except format and samples, and requires the caller
+    to fill in *all* the fields in either of the exclusive groups.
 
     If any field is missing from the first exclusive group, and the tracecount
     is set, the resulting file will be considered unstructured. If the
@@ -207,7 +205,10 @@ def create(filename, spec):
     f._samples       = samples
 
     if structured(spec):
-        f.interpret(spec.ilines, spec.xlines, spec.offsets, spec.sorting)
+        sorting = spec.sorting if hasattr(spec, 'sorting') else None
+        if sorting is None:
+            sorting = TraceSortingFormat.INLINE_SORTING
+        f.interpret(spec.ilines, spec.xlines, spec.offsets, sorting)
 
     f.text[0] = default_text_header(f._il, f._xl, segyio.TraceField.offset)
 

--- a/python/test/segy.py
+++ b/python/test/segy.py
@@ -20,7 +20,7 @@ from pytest import approx
 from . import tmpfiles, small, smallps
 
 import segyio
-from segyio import TraceField, BinField
+from segyio import TraceField, BinField, TraceSortingFormat
 from segyio.field import Field
 from segyio.line import Line, HeaderLine
 from segyio.trace import Trace, Header
@@ -1193,7 +1193,7 @@ def test_create_sgy_shorter_traces(small):
 def test_create_from_naught(endian, tmpdir):
     spec = segyio.spec()
     spec.format = 5
-    spec.sorting = 2
+    spec.sorting = 1
     spec.samples = range(150)
     spec.ilines = range(1, 11)
     spec.xlines = range(1, 6)
@@ -1223,12 +1223,14 @@ def test_create_from_naught(endian, tmpdir):
         assert f.header[0][TraceField.offset] == f.header[1][TraceField.offset]
         assert 1 == f.header[1][TraceField.offset]
 
+        assert f.sorting == TraceSortingFormat.CROSSLINE_SORTING
+
 
 @pytest.mark.parametrize('endian', ['lsb', 'msb'])
 def test_create_from_naught_prestack(endian, tmpdir):
     spec = segyio.spec()
     spec.format = 5
-    spec.sorting = 2
+    #spec.sorting not set by test design
     spec.samples = range(7)
     spec.ilines = range(1, 4)
     spec.xlines = range(1, 3)
@@ -1266,6 +1268,8 @@ def test_create_from_naught_prestack(endian, tmpdir):
 
         for x, y in zip(f.iline[:, :], cube):
             assert list(x.flatten()) == list(y.flatten())
+
+        assert f.sorting == TraceSortingFormat.INLINE_SORTING
 
 
 @pytest.mark.parametrize('endian', ['lsb', 'msb'])
@@ -1420,11 +1424,6 @@ def test_create_bad_specs(tmpdir):
             pass
 
     c.offsets = [1]
-    with pytest.raises(AttributeError):
-        with segyio.create(tmpdir / 'offsets', c):
-            pass
-
-    c.sorting = 2
     with segyio.create(tmpdir / 'ok.sgy', c):
         pass
 


### PR DESCRIPTION
If no explicit value for file specification is provided, segyio should
assume inline sorting is expected. Changed, updated one of the 'create'
tests

Fixes #292 