### PR TITLE
Test endianness in segy.c properly

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+# 1.8.3
+* Check endianness variable properly
+
 # 1.8.2
 * Pass HOST_BIG_ENDIAN as preprocessor directive, not compiler option
 

--- a/lib/src/segy.c
+++ b/lib/src/segy.c
@@ -102,7 +102,7 @@ static int encode( char* dst,
 #endif // __GNUC__
 
 static uint16_t htobe16( uint16_t v ) {
-#ifdef HOST_LSB
+#if HOST_LSB
     return bswap16(v);
 #else
     return v;
@@ -110,7 +110,7 @@ static uint16_t htobe16( uint16_t v ) {
 }
 
 static uint32_t htobe32( uint32_t v ) {
-#ifdef HOST_LSB
+#if HOST_LSB
     return bswap32(v);
 #else
     return v;
@@ -118,7 +118,7 @@ static uint32_t htobe32( uint32_t v ) {
 }
 
 static uint16_t be16toh( uint16_t v ) {
-#ifdef HOST_LSB
+#if HOST_LSB
     return bswap16(v);
 #else
     return v;
@@ -126,7 +126,7 @@ static uint16_t be16toh( uint16_t v ) {
 }
 
 static uint32_t be32toh( uint32_t v ) {
-#ifdef HOST_LSB
+#if HOST_LSB
     return bswap32(v);
 #else
     return v;


### PR DESCRIPTION
The HOST_MSB and HOST_LSB preprocessor variables are always set, meaning
that HOST_LSB will always be defined. The correct check is if, not
ifdef, and so code would always be little-endian