### PR TITLE
Refactor from_array to write files trace-by-trace

### DIFF
--- a/README.md
+++ b/README.md
@@ -496,39 +496,7 @@ with segyio.open(output_file, "r+") as src:
         src.iline[i] = 2 * src.iline[i]
 ```
 
-Make segy file from sctrach
-
-```python
-spec = segyio.spec()
-filename = 'name_of_your_file.sgy'
-
-spec = segyio.spec()
-file_out = 'test1.sgy'
-
-spec.sorting = 2
-spec.format = 1
-spec.samples = np.arange(30)
-spec.ilines = np.arange(10)
-spec.xlines = np.arange(20)
-
-with segyio.create(filename, spec) as f:
-
-    # write the line itself to the file and the inline number in all this line's headers
-    for ilno in spec.ilines:
-        f.iline[ilno] = np.zeros(
-            (len(spec.xlines), spec.samples), dtype=np.single) + ilno
-        f.header.iline[ilno] = {
-            segyio.TraceField.INLINE_3D: ilno,
-            segyio.TraceField.offset: 0
-        }
-
-    # then do the same for xlines
-    for xlno in spec.xlines:
-        f.header.xline[xlno] = {
-            segyio.TraceField.CROSSLINE_3D: xlno,
-            segyio.TraceField.TRACE_SAMPLE_INTERVAL: 4000
-        }
-```
+[Make segy file from sctrach](python/examples/make-file.py)
 
 Visualize data using sibling tool [SegyViewer](https://github.com/Statoil/segyviewer):
 

--- a/python/examples/make-file.py
+++ b/python/examples/make-file.py
@@ -35,21 +35,22 @@ def main():
                           step  = step,
                           dtype = np.single)
 
-        # one inline is N traces concatenated. We fill in the xline number
-        line = np.concatenate([trace + (xl / 100.0) for xl in spec.xlines])
-        line = line.reshape( (len(spec.xlines), len(spec.samples)) )
+        # Write the file trace-by-trace and update headers with iline, xline
+        # and offset
+        tr = 0
+        for il in spec.ilines:
+            for xl in spec.xlines:
+                f.header[tr] = {
+                    segyio.su.offset : 1,
+                    segyio.su.iline  : il,
+                    segyio.su.xline  : xl
+                }
+                f.trace[tr] = trace + (xl / 100.0) + il
+                tr += 1
 
-        # write the line itself to the file
-        # write the inline number in all this line's headers
-        for ilno in spec.ilines:
-            f.iline[ilno] = (line + ilno)
-            f.header.iline[ilno] = { segyio.TraceField.INLINE_3D: ilno,
-                                     segyio.TraceField.offset: 1
-                                   }
-
-        # then do the same for xlines
-        for xlno in spec.xlines:
-            f.header.xline[xlno] = { segyio.TraceField.CROSSLINE_3D: xlno }
+        f.bin.update(
+            tsort=segyio.TraceSortingFormat.INLINE_SORTING
+        )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Writing headers line-by-line is a huge performance hit compared to
writing trace-by-trace

As it is not nessesarily obivious to the regular user that there is a
performance hit by writing line-by-line, the examples on how to create a
file should use trace-by-trace writing to encurage trace-by-trace
writing

connects #346 
closes #346 